### PR TITLE
[pkg/quantile] Backport fix for 'count greater than sum of bins' edge case

### DIFF
--- a/.chloggen/mx-psi_backport-count-greater-than-bins.yaml
+++ b/.chloggen/mx-psi_backport-count-greater-than-bins.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component (e.g. pkg/quantile)
+component: pkg/quantile
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Handle edge case where total count exceeds sum of bins after conversion from other formats.
+
+# The PR related to this change
+issues: [11]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/pkg/quantile/sparse.go
+++ b/pkg/quantile/sparse.go
@@ -31,8 +31,9 @@ func (s *Sketch) String() string {
 }
 
 // MemSize returns memory use in bytes:
-//   used: uses len(bins)
-//   allocated: uses cap(bins)
+//
+//	used: uses len(bins)
+//	allocated: uses cap(bins)
 func (s *Sketch) MemSize() (used, allocated int) {
 	const (
 		basicSize = int(unsafe.Sizeof(summary.Summary{}))
@@ -85,8 +86,9 @@ func (s *Sketch) Merge(c *Config, o *Sketch) {
 // Quantile returns v such that s.count*q items are <= v.
 //
 // Special cases are:
-//	Quantile(c, q <= 0)  = min
-//  Quantile(c, q >= 1)  = max
+//
+//		Quantile(c, q <= 0)  = min
+//	 Quantile(c, q >= 1)  = max
 func (s *Sketch) Quantile(c *Config, q float64) float64 {
 	switch {
 	case s.count == 0:
@@ -128,8 +130,8 @@ func (s *Sketch) Quantile(c *Config, q float64) float64 {
 		// return vLow
 	}
 
-	// this should never happen
-	return math.NaN()
+	// this can happen if count is greater than sum of bins
+	return s.Basic.Max
 }
 
 func rank(count int, q float64) float64 {

--- a/pkg/quantile/sparse_test.go
+++ b/pkg/quantile/sparse_test.go
@@ -173,6 +173,34 @@ func TestQuantile(t *testing.T) {
 	}
 }
 
+func IsClose(t *testing.T, expected, actual float64) {
+	t.Helper()
+	min := expected - math.Abs(expected*defaultEps)
+	max := expected + math.Abs(expected*defaultEps)
+	if actual < min {
+		t.Fatalf("actual %v is greater than min allowed: %v", actual, min)
+	}
+	if actual > max {
+		t.Fatalf("actual %v is greater than max allowed: %v", actual, max)
+	}
+}
+
+func TestQuantileDDGo(t *testing.T) {
+	c := Default()
+	t.Run("Test count greater than sum of bins", func(t *testing.T) {
+		ta := require.New(t)
+
+		s := arange(t, c, 1, 101)
+		q := s.Quantile(c, .99)
+		ta.NotEqual(s.Basic.Max, q, "should not be max from sketch")
+
+		// Count bigger than sum of bin counts
+		s.count = 200
+		q = s.Quantile(c, .99)
+		ta.Equal(s.Basic.Max, q, "should be max from sketch")
+	})
+}
+
 func TestRank(t *testing.T) {
 	t.Run("101", func(t *testing.T) {
 		// when cnt=101:


### PR DESCRIPTION
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Backports fix to Quantile method when the count is greater than the sum of the bins (DataDog/dd-go@f457099e9071709785f5cd4982cd6530c8931468). This can happen after conversion from other formats (such as ExponentialHistograms!) because of rounding/floating-point errors.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Consistency with internal version of this module.
