### PR TITLE
Add support for OTel .NET runtime metrics

### DIFF
--- a/pkg/otlp/metrics/metrics_translator.go
+++ b/pkg/otlp/metrics/metrics_translator.go
@@ -511,8 +511,13 @@ func mapGaugeMetricWithAttributes(md pmetric.Metric, metricsArray pmetric.Metric
 }
 
 func mapSumMetricWithAttributes(md pmetric.Metric, metricsArray pmetric.MetricSlice, mp mapping) {
+	fmt.Printf("-------- IN MAP SUM METRIC ----------\n")
+	fmt.Printf("-------- md.name: %v ----------\n", md.Name())
+	fmt.Printf("-------- mp: %+v ----------\n", mp)
+
 	for i := 0; i < md.Sum().DataPoints().Len(); i++ {
 		attribute, _ := md.Sum().DataPoints().At(i).Attributes().Get(mp.attribute)
+		fmt.Printf("-------- attribute: %v ----------\n", attribute.AsString())
 		cp := metricsArray.AppendEmpty()
 		cp.SetEmptySum()
 

--- a/pkg/otlp/metrics/metrics_translator.go
+++ b/pkg/otlp/metrics/metrics_translator.go
@@ -505,8 +505,8 @@ func mapGaugeRuntimeMetricWithAttributes(md pmetric.Metric, metricsArray pmetric
 	cp := metricsArray.AppendEmpty()
 	cp.SetEmptyGauge()
 	for i := 0; i < md.Gauge().DataPoints().Len(); i++ {
-		attribute, _ := md.Gauge().DataPoints().At(i).Attributes().Get(mp.attribute)
-		if attribute.AsString() == mp.attributeValue {
+		attribute, res := md.Gauge().DataPoints().At(i).Attributes().Get(mp.attribute)
+		if res && attribute.AsString() == mp.attributeValue {
 			md.Gauge().DataPoints().At(i).CopyTo(cp.Gauge().DataPoints().AppendEmpty())
 			cp.SetName(mp.mappedName)
 		}
@@ -520,8 +520,8 @@ func mapSumRuntimeMetricWithAttributes(md pmetric.Metric, metricsArray pmetric.M
 	cp.Sum().SetAggregationTemporality(md.Sum().AggregationTemporality())
 	cp.Sum().SetIsMonotonic(md.Sum().IsMonotonic())
 	for i := 0; i < md.Sum().DataPoints().Len(); i++ {
-		attribute, _ := md.Sum().DataPoints().At(i).Attributes().Get(mp.attribute)
-		if attribute.AsString() == mp.attributeValue {
+		attribute, res := md.Sum().DataPoints().At(i).Attributes().Get(mp.attribute)
+		if res && attribute.AsString() == mp.attributeValue {
 			md.Sum().DataPoints().At(i).CopyTo(cp.Sum().DataPoints().AppendEmpty())
 			cp.SetName(mp.mappedName)
 		}

--- a/pkg/otlp/metrics/metrics_translator.go
+++ b/pkg/otlp/metrics/metrics_translator.go
@@ -514,13 +514,13 @@ func mapSumMetricWithAttributes(md pmetric.Metric, metricsArray pmetric.MetricSl
 	fmt.Printf("-------- IN MAP SUM METRIC ----------\n")
 	fmt.Printf("-------- md.name: %v ----------\n", md.Name())
 	fmt.Printf("-------- mp: %+v ----------\n", mp)
-
+	cp := metricsArray.AppendEmpty()
+	cp.SetEmptySum()
+	cp.Sum().SetAggregationTemporality(md.Sum().AggregationTemporality())
+	cp.Sum().SetIsMonotonic(md.Sum().IsMonotonic())
 	for i := 0; i < md.Sum().DataPoints().Len(); i++ {
 		attribute, _ := md.Sum().DataPoints().At(i).Attributes().Get(mp.attribute)
 		fmt.Printf("-------- attribute: %v ----------\n", attribute.AsString())
-		cp := metricsArray.AppendEmpty()
-		cp.SetEmptySum()
-
 		if attribute.AsString() == mp.attributeValue {
 			md.Sum().DataPoints().At(i).CopyTo(cp.Sum().DataPoints().AppendEmpty())
 			cp.SetName(mp.mappedName)

--- a/pkg/otlp/metrics/metrics_translator.go
+++ b/pkg/otlp/metrics/metrics_translator.go
@@ -33,7 +33,7 @@ import (
 	"github.com/DataDog/opentelemetry-mapping-go/pkg/quantile"
 )
 
-type mapping struct {
+type runtimeMetricMapping struct {
 	mappedName     string
 	attribute      string
 	attributeValue string
@@ -42,7 +42,7 @@ type mapping struct {
 
 // runtimeMetricsMappings defines the mappings from OTel runtime metric names to their
 // equivalent Datadog runtime metric names
-var runtimeMetricsMappings = map[string][]mapping{
+var runtimeMetricsMappings = map[string][]runtimeMetricMapping{
 	"process.runtime.go.goroutines":                        {{mappedName: "runtime.go.num_goroutine"}},
 	"process.runtime.go.cgo.calls":                         {{mappedName: "runtime.go.num_cgo_call"}},
 	"process.runtime.go.lookups":                           {{mappedName: "runtime.go.mem_stats.lookups"}},
@@ -498,7 +498,7 @@ func (t *Translator) source(m pcommon.Map) (source.Source, error) {
 	return src, nil
 }
 
-func mapGaugeMetricWithAttributes(md pmetric.Metric, metricsArray pmetric.MetricSlice, mp mapping) {
+func mapGaugeMetricWithAttributes(md pmetric.Metric, metricsArray pmetric.MetricSlice, mp runtimeMetricMapping) {
 	cp := metricsArray.AppendEmpty()
 	cp.SetEmptyGauge()
 	for i := 0; i < md.Gauge().DataPoints().Len(); i++ {
@@ -510,7 +510,7 @@ func mapGaugeMetricWithAttributes(md pmetric.Metric, metricsArray pmetric.Metric
 	}
 }
 
-func mapSumMetricWithAttributes(md pmetric.Metric, metricsArray pmetric.MetricSlice, mp mapping) {
+func mapSumMetricWithAttributes(md pmetric.Metric, metricsArray pmetric.MetricSlice, mp runtimeMetricMapping) {
 	fmt.Printf("-------- IN MAP SUM METRIC ----------\n")
 	fmt.Printf("-------- md.name: %v ----------\n", md.Name())
 	fmt.Printf("-------- mp: %+v ----------\n", mp)

--- a/pkg/otlp/metrics/metrics_translator.go
+++ b/pkg/otlp/metrics/metrics_translator.go
@@ -581,10 +581,9 @@ func (t *Translator) MapMetrics(ctx context.Context, md pmetric.Metrics, consume
 							cp.SetName(mp.mappedName)
 							break
 						}
-						switch mp.metricType {
-						case pmetric.MetricTypeSum:
+						if mp.metricType == pmetric.MetricTypeSum {
 							mapSumMetricWithAttributes(md, metricsArray, mp)
-						case pmetric.MetricTypeGauge:
+						} else if mp.metricType == pmetric.MetricTypeGauge {
 							mapGaugeMetricWithAttributes(md, metricsArray, mp)
 						}
 					}

--- a/pkg/otlp/metrics/metrics_translator.go
+++ b/pkg/otlp/metrics/metrics_translator.go
@@ -577,8 +577,12 @@ func (t *Translator) MapMetrics(ctx context.Context, md pmetric.Metrics, consume
 
 			for k := 0; k < metricsArray.Len(); k++ {
 				md := metricsArray.At(k)
+				fmt.Printf("---------- IN MAP METRICS -----------\n")
+				fmt.Printf("---------- md.name: %v -----------\n", md.Name())
 				if v, ok := runtimeMetricsMappings[md.Name()]; ok {
 					for _, mp := range v {
+						fmt.Printf("---------- mp.attribute: %v -----------\n", mp.attribute)
+						fmt.Printf("---------- mp.metricType: %v -----------\n", mp.metricType)
 						if mp.attribute == "" {
 							// duplicate runtime metrics as Datadog runtime metrics
 							cp := metricsArray.AppendEmpty()

--- a/pkg/otlp/metrics/metrics_translator_test.go
+++ b/pkg/otlp/metrics/metrics_translator_test.go
@@ -161,7 +161,7 @@ func newDims(name string) *Dimensions {
 }
 
 func newGauge(dims *Dimensions, ts uint64, val float64) metric {
-	return metric{name: dims.name, typ: Gauge, timestamp: ts, value: val, tags: dims.tags}
+	return newGaugeWithHost(dims, ts, val, "")
 }
 
 func newGaugeWithHost(dims *Dimensions, ts uint64, val float64, host string) metric {

--- a/pkg/otlp/metrics/metrics_translator_test.go
+++ b/pkg/otlp/metrics/metrics_translator_test.go
@@ -16,6 +16,7 @@ package metrics
 
 import (
 	"context"
+	"fmt"
 	"math"
 	"testing"
 	"time"
@@ -161,6 +162,10 @@ func newDims(name string) *Dimensions {
 
 func newGauge(dims *Dimensions, ts uint64, val float64) metric {
 	return metric{name: dims.name, typ: Gauge, timestamp: ts, value: val, tags: dims.tags}
+}
+
+func newGaugeWithHost(dims *Dimensions, ts uint64, val float64, host string) metric {
+	return metric{name: dims.name, typ: Gauge, timestamp: ts, value: val, tags: dims.tags, host: host}
 }
 
 func newCount(dims *Dimensions, ts uint64, val float64) metric {
@@ -415,6 +420,46 @@ func TestMapRuntimeMetricsHasMapping(t *testing.T) {
 			newCountWithHost(mappedDims, uint64(seconds(startTs+1)), 10, fallbackHostname),
 			newCountWithHost(mappedDims, uint64(seconds(startTs+2)), 5, fallbackHostname),
 			newCountWithHost(mappedDims, uint64(seconds(startTs+3)), 5, fallbackHostname),
+		},
+	)
+}
+
+func TestMapSumRuntimeMetricWithAttributesHasMapping(t *testing.T) {
+	ctx := context.Background()
+	tr := newTranslator(t, zap.NewNop())
+	consumer := &mockFullConsumer{}
+	if err := tr.MapMetrics(ctx, createTestMetricWithAttributes(false, "process.runtime.dotnet.gc.collections.count", pmetric.MetricTypeSum, "generation", "gen"), consumer); err != nil {
+		t.Fatal(err)
+	}
+	startTs := int(getProcessStartTime()) + 1
+	assert.ElementsMatch(t,
+		consumer.metrics,
+		[]metric{
+			newCountWithHost(newDims("process.runtime.dotnet.gc.collections.count").AddTags("generation:gen0"), uint64(seconds(startTs+1)), 10, fallbackHostname),
+			newCountWithHost(newDims("runtime.dotnet.gc.count.gen0").AddTags("generation:gen0"), uint64(seconds(startTs+1)), 10, fallbackHostname),
+			newCountWithHost(newDims("runtime.dotnet.gc.count.gen1").AddTags("generation:gen1"), uint64(seconds(startTs+2)), 15, fallbackHostname),
+			newCountWithHost(newDims("runtime.dotnet.gc.count.gen2").AddTags("generation:gen2"), uint64(seconds(startTs+3)), 20, fallbackHostname),
+		},
+	)
+}
+
+func TestMapGaugeRuntimeMetricWithAttributesHasMapping(t *testing.T) {
+	ctx := context.Background()
+	tr := newTranslator(t, zap.NewNop())
+	consumer := &mockFullConsumer{}
+	if err := tr.MapMetrics(ctx, createTestMetricWithAttributes(false, "process.runtime.dotnet.gc.heap.size", pmetric.MetricTypeGauge, "generation", "gen"), consumer); err != nil {
+		t.Fatal(err)
+	}
+	startTs := int(getProcessStartTime()) + 1
+	assert.ElementsMatch(t,
+		consumer.metrics,
+		[]metric{
+			newGaugeWithHost(newDims("process.runtime.dotnet.gc.heap.size").AddTags("generation:gen0"), uint64(seconds(startTs+1)), 10, fallbackHostname),
+			newGaugeWithHost(newDims("process.runtime.dotnet.gc.heap.size").AddTags("generation:gen1"), uint64(seconds(startTs+2)), 15, fallbackHostname),
+			newGaugeWithHost(newDims("process.runtime.dotnet.gc.heap.size").AddTags("generation:gen2"), uint64(seconds(startTs+3)), 20, fallbackHostname),
+			newGaugeWithHost(newDims("runtime.dotnet.gc.size.gen0").AddTags("generation:gen0"), uint64(seconds(startTs+1)), 10, fallbackHostname),
+			newGaugeWithHost(newDims("runtime.dotnet.gc.size.gen1").AddTags("generation:gen1"), uint64(seconds(startTs+2)), 15, fallbackHostname),
+			newGaugeWithHost(newDims("runtime.dotnet.gc.size.gen2").AddTags("generation:gen2"), uint64(seconds(startTs+3)), 20, fallbackHostname),
 		},
 	)
 }
@@ -778,6 +823,37 @@ func createTestDoubleCumulativeMonotonicMetrics(tsmatch bool) pmetric.Metrics {
 			dpInt.SetTimestamp(seconds(startTs + i + 1))
 		}
 		dpInt.SetDoubleValue(val)
+	}
+	return md
+}
+
+func createTestMetricWithAttributes(tsmatch bool, metricName string, metricType pmetric.MetricType, attribute string, attributeValue string) pmetric.Metrics {
+	md := pmetric.NewMetrics()
+	met := md.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+	met.SetName(metricName)
+	var dpsInt pmetric.NumberDataPointSlice
+	if metricType == pmetric.MetricTypeSum {
+		met.SetEmptySum()
+		met.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+		met.Sum().SetIsMonotonic(true)
+		dpsInt = met.Sum().DataPoints()
+	} else if metricType == pmetric.MetricTypeGauge {
+		met.SetEmptyGauge()
+		dpsInt = met.Gauge().DataPoints()
+	}
+	values := []int64{10, 15, 20}
+	dpsInt.EnsureCapacity(len(values))
+	startTs := int(getProcessStartTime()) + 1
+	for i, val := range values {
+		dpInt := dpsInt.AppendEmpty()
+		dpInt.Attributes().PutStr(attribute, fmt.Sprintf("%v%v", attributeValue, i))
+		dpInt.SetStartTimestamp(seconds(startTs))
+		if tsmatch {
+			dpInt.SetTimestamp(seconds(startTs))
+		} else {
+			dpInt.SetTimestamp(seconds(startTs + i + 1))
+		}
+		dpInt.SetIntValue(val)
 	}
 	return md
 }


### PR DESCRIPTION
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->
Adds mappings for .NET runtime metrics and adds mapping code to handle metrics with attributes that need to be mapped to Datadog runtime metrics. In order to do this, I refactored how we store runtime metric mappings to support this nested data structure.

For example, the OTel runtime metric `process.runtime.dotnet.gc.collections.count` has attributes `gen0, gen1, gen2`. The `gen0` attribute on this metric maps directly to the Datadog runtime metric `runtime.dotnet.gc.count.gen0`.
