### PR TITLE
Add more histogram and exponential histogram tests

### DIFF
--- a/internal/tools/generate-license-file/main.go
+++ b/internal/tools/generate-license-file/main.go
@@ -22,6 +22,7 @@ var (
 		"pkg/quantile",
 		"pkg/otlp/attributes",
 		"pkg/otlp/metrics",
+		"pkg/internal/sketchtest",
 	}
 )
 

--- a/pkg/internal/sketchtest/go.mod
+++ b/pkg/internal/sketchtest/go.mod
@@ -1,0 +1,11 @@
+module github.com/DataDog/opentelemetry-mapping-go/pkg/internal/sketchtest
+
+go 1.19
+
+require github.com/stretchr/testify v1.8.2
+
+require (
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/pkg/internal/sketchtest/go.sum
+++ b/pkg/internal/sketchtest/go.sum
@@ -1,0 +1,17 @@
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
+github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/objx v0.4.0/go.mod h1:YvHI0jy2hoMjB+UWwv71VJQ9isScKT/TqJzVSSt89Yw=
+github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpEOglKo=
+github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
+github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
+github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/internal/sketchtest/quantile.go
+++ b/pkg/internal/sketchtest/quantile.go
@@ -1,0 +1,112 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2022-present Datadog, Inc.
+
+// package distrotest is an internal module with test helpers for generating points from a given distribution.
+package sketchtest
+
+import "math"
+
+// QuantileFunction for a distribution. The function MUST be defined in (0,1).
+// The function MAY return the minimum at 0 and the maximum at 1, for distributions where this
+// makes sense.
+type QuantileFunction func(float64) float64
+
+// CDF is the cumulative distribution function of a distribution (inverse of QuantileFunction).
+type CDF func(float64) float64
+
+// UniformQ returns the quantile function for an uniform distribution
+// with parameters a and b.
+// See https://en.wikipedia.org/wiki/Continuous_uniform_distribution
+func UniformQ(a, b float64) QuantileFunction {
+	return func(q float64) float64 {
+		return (b-a)*q + a
+	}
+}
+
+// UQuadraticQ returns the quantile function for an U-Quadratic distribution
+// with parameters a and b.
+// See https://en.wikipedia.org/wiki/U-quadratic_distribution
+func UQuadraticQ(a, b float64) QuantileFunction {
+	return func(q float64) float64 {
+		alpha := 12.0 / math.Pow(b-a, 3)
+		beta := (b + a) / 2.0
+
+		// golang's math.Pow doesn't like negative numbers as the first argument
+		// (it will return NaN), even though cubic roots of negative numbers are defined.
+		sign := 1.0
+		if 3/alpha*q-math.Pow(beta-a, 3) < 0 {
+			sign = -1.0
+		}
+		return beta + sign*math.Pow(sign*(3/alpha*q-math.Pow(beta-a, 3)), 1.0/3.0)
+	}
+}
+
+// Truncate a quantile function to the interval [a,b] given its CDF.
+// See https://en.wikipedia.org/wiki/Truncated_distribution.
+// This function assumes but does not check that quantile is the inverse of cdf.
+func TruncateQ(a, b float64, quantile QuantileFunction, cdf CDF) QuantileFunction {
+	// inverse of x ↦ (x - F(a))/(F(b) - F(a))
+	h := func(cdfx float64) float64 { return (cdf(b)-cdf(a))*cdfx + cdf(a) }
+
+	return func(q float64) float64 {
+		// handle extrema separately to support cdf not defined at these points.
+		switch q {
+		case 0:
+			// quantile(h(0)) = quantile(cdf(a)) = a
+			return a
+		case 1:
+			// quantile(h(1)) = quantile(cdf(b)) = b
+			return b
+		}
+		return quantile(h(q))
+	}
+}
+
+// Truncate a CDF to the interval (a,b).
+// See https://en.wikipedia.org/wiki/Truncated_distribution.
+func TruncateCDF(a, b float64, cdf CDF) CDF {
+	return func(x float64) float64 {
+		return (cdf(x) - cdf(a)) / (cdf(b) - cdf(a))
+	}
+}
+
+// ExponentialCDF is the CDF of the Exponential distribution
+// with parameter lambda.
+// See https://en.wikipedia.org/wiki/Exponential_distribution
+func ExponentialCDF(lambda float64) CDF {
+	return func(x float64) float64 {
+		if x < 0 {
+			return 0
+		}
+		return 1 - math.Exp(-lambda*x)
+	}
+}
+
+// ExponentialQ is the quantile function of the Exponential distribution
+// with parameter lambda
+// See https://en.wikipedia.org/wiki/Exponential_distribution
+func ExponentialQ(lambda float64) QuantileFunction {
+	return func(q float64) float64 {
+		return -math.Log(1-q) / lambda
+	}
+}
+
+// NormalCDF is the CDF of the Normal distribution
+// with parameters mu and sigma.
+// See https://en.wikipedia.org/wiki/Normal_distribution
+func NormalCDF(mu, sigma float64) CDF {
+	return func(x float64) float64 {
+		return 1.0 / 2.0 * (1 + math.Erf((x-mu)/(sigma*math.Sqrt2)))
+	}
+}
+
+// NormalQ is the quantile function of the Normal distribution
+// with parameters mu and sigma.
+// See https://en.wikipedia.org/wiki/Normal_distribution
+func NormalQ(mu, sigma float64) QuantileFunction {
+	return func(q float64) float64 {
+		return mu + sigma*math.Sqrt2*math.Erfinv(2*q-1)
+	}
+}

--- a/pkg/internal/sketchtest/quantile.go
+++ b/pkg/internal/sketchtest/quantile.go
@@ -3,7 +3,7 @@
 // This product includes software developed at Datadog (https://www.datadoghq.com/).
 // Copyright 2022-present Datadog, Inc.
 
-// package distrotest is an internal module with test helpers for generating points from a given distribution.
+// package sketchtest is an internal module with test helpers for generating points from a given distribution.
 package sketchtest
 
 import "math"

--- a/pkg/internal/sketchtest/quantile_test.go
+++ b/pkg/internal/sketchtest/quantile_test.go
@@ -1,0 +1,45 @@
+package sketchtest
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestQuantileCDFInverses(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		cdf  CDF
+		qf   QuantileFunction
+	}{
+		{
+			name: "Exponential(lambda=1/100)",
+			cdf:  ExponentialCDF(1 / 100.0),
+			qf:   ExponentialQ(1 / 100.0),
+		},
+		{
+			name: "Exponential(lambda=1/200)",
+			cdf:  ExponentialCDF(1 / 200.0),
+			qf:   ExponentialQ(1 / 200.0),
+		},
+		{
+			name: "Normal(0, 1)",
+			cdf:  NormalCDF(0, 1),
+			qf:   NormalQ(0, 1),
+		},
+		{
+			name: "Normal(-3, 10)",
+			cdf:  NormalCDF(-3, 10),
+			qf:   NormalQ(-3, 10),
+		},
+		{
+			name: "Truncated normal (0, 1e-3)",
+			cdf:  TruncateCDF(-8, 8, NormalCDF(0, 1e-3)),
+			qf:   TruncateQ(-8, 8, NormalQ(0, 1e-3), NormalCDF(0, 1e-3)),
+		},
+	} {
+		for i := 0; i <= 100; i++ {
+			assert.InDelta(t, tt.cdf(tt.qf(float64(i)/100.0)), float64(i)/100.0, 1e-15)
+		}
+	}
+}

--- a/pkg/otlp/metrics/go.mod
+++ b/pkg/otlp/metrics/go.mod
@@ -4,12 +4,14 @@ go 1.19
 
 require (
 	github.com/DataDog/datadog-agent/pkg/trace v0.43.0-rc.3.0.20230206114529-17c7dfde736c
+	github.com/DataDog/opentelemetry-mapping-go/pkg/internal/sketchtest v0.0.0-00010101000000-000000000000
 	github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes v0.1.2
 	github.com/DataDog/opentelemetry-mapping-go/pkg/quantile v0.1.2
 	github.com/DataDog/sketches-go v1.4.1
 	github.com/golang/protobuf v1.5.2
+	github.com/lightstep/go-expohisto v1.0.0
 	github.com/patrickmn/go-cache v2.1.0+incompatible
-	github.com/stretchr/testify v1.8.1
+	github.com/stretchr/testify v1.8.2
 	go.opentelemetry.io/collector/pdata v1.0.0-rc5
 	go.uber.org/zap v1.24.0
 )
@@ -37,6 +39,7 @@ require (
 )
 
 replace (
+	github.com/DataDog/opentelemetry-mapping-go/pkg/internal/sketchtest => ../../internal/sketchtest
 	github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes => ../attributes
 	github.com/DataDog/opentelemetry-mapping-go/pkg/quantile => ../../quantile
 )

--- a/pkg/otlp/metrics/go.sum
+++ b/pkg/otlp/metrics/go.sum
@@ -22,6 +22,8 @@ github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnr
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/lightstep/go-expohisto v1.0.0 h1:UPtTS1rGdtehbbAF7o/dhkWLTDI73UifG8LbfQI7cA4=
+github.com/lightstep/go-expohisto v1.0.0/go.mod h1:xDXD0++Mu2FOaItXtdDfksfgxfV0z1TMPa+e/EUd0cs=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd h1:TRLaZ9cD/w8PVh93nsPXa1VrQ6jlwL5oN8l14QlcNfg=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
@@ -41,8 +43,8 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
-github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
-github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
+github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 github.com/tinylib/msgp v1.1.6 h1:i+SbKraHhnrf9M5MYmvQhFnbLhAXSDWF8WWsuyRdocw=
 github.com/tinylib/msgp v1.1.6/go.mod h1:75BAfg2hauQhs3qedfdDZmWAPcFMAvJE5b9rGOMufyw=
 github.com/vmihailenco/msgpack/v4 v4.3.12 h1:07s4sz9IReOgdikxLTKNbBdqDMLsjPKXwvCazn8G65U=

--- a/pkg/otlp/metrics/histograms_test.go
+++ b/pkg/otlp/metrics/histograms_test.go
@@ -21,6 +21,7 @@ func TestDeltaHistogramTranslatorOptions(t *testing.T) {
 		otlpfile string
 		ddogfile string
 		options  []TranslatorOption
+		err      string
 	}{
 		{
 			name:     "distributions",
@@ -65,11 +66,22 @@ func TestDeltaHistogramTranslatorOptions(t *testing.T) {
 				WithCountSumMetrics(),
 			},
 		},
+		{
+			name: "no-count-sum-no-buckets",
+			options: []TranslatorOption{
+				WithHistogramMode(HistogramModeNoBuckets),
+			},
+			err: errNoBucketsNoSumCount,
+		},
 	}
 
 	for _, testinstance := range tests {
 		t.Run(testinstance.name, func(t *testing.T) {
 			translator, err := NewTranslator(zap.NewNop(), testinstance.options...)
+			if testinstance.err != "" {
+				assert.EqualError(t, err, testinstance.err)
+				return
+			}
 			require.NoError(t, err)
 			AssertTranslatorMap(t, translator, testinstance.otlpfile, testinstance.ddogfile)
 		})

--- a/pkg/otlp/metrics/metrics_translator.go
+++ b/pkg/otlp/metrics/metrics_translator.go
@@ -98,7 +98,10 @@ var runtimeMetricsMappings = map[string][]runtimeMetricMapping{
 	}},
 }
 
-const metricName string = "metric name"
+const (
+	metricName             string = "metric name"
+	errNoBucketsNoSumCount string = "no buckets mode and no send count sum are incompatible"
+)
 
 var _ source.Provider = (*noSourceProvider)(nil)
 
@@ -137,7 +140,7 @@ func NewTranslator(logger *zap.Logger, options ...TranslatorOption) (*Translator
 	}
 
 	if cfg.HistMode == HistogramModeNoBuckets && !cfg.SendCountSum {
-		return nil, errors.New("no buckets mode and no send count sum are incompatible")
+		return nil, errors.New(errNoBucketsNoSumCount)
 	}
 
 	cache := newTTLCache(cfg.sweepInterval, cfg.deltaTTL)

--- a/pkg/otlp/metrics/sketches_test.go
+++ b/pkg/otlp/metrics/sketches_test.go
@@ -365,6 +365,17 @@ func TestInfiniteBounds(t *testing.T) {
 		getHist func() pmetric.Metrics
 	}{
 		{
+			name: "(-inf, inf): 0",
+			getHist: func() pmetric.Metrics {
+				p := pmetric.NewHistogramDataPoint()
+				p.ExplicitBounds().FromRaw([]float64{})
+				p.BucketCounts().FromRaw([]uint64{0})
+				p.SetCount(0)
+				p.SetSum(0)
+				return newHistogramMetric(p)
+			},
+		},
+		{
 			name: "(-inf, inf): 100",
 			getHist: func() pmetric.Metrics {
 				p := pmetric.NewHistogramDataPoint()
@@ -415,6 +426,12 @@ func TestInfiniteBounds(t *testing.T) {
 			sk := consumer.sk
 
 			p := md.ResourceMetrics().At(0).ScopeMetrics().At(0).Metrics().At(0).Histogram().DataPoints().At(0)
+			if p.Count() == 0 {
+				// Check that no point is produced if the count is zero.
+				assert.Nil(t, sk)
+				// Nothing to assert, end early
+				return
+			}
 			assert.InDelta(t, sk.Basic.Sum, p.Sum(), 1)
 			assert.Equal(t, uint64(sk.Basic.Cnt), p.Count())
 			assert.Equal(t, sk.Basic.Min, p.Min())

--- a/pkg/otlp/metrics/sketches_test.go
+++ b/pkg/otlp/metrics/sketches_test.go
@@ -19,12 +19,17 @@ import (
 	"fmt"
 	"math"
 	"testing"
+	"time"
 
+	"github.com/lightstep/go-expohisto/structure"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.uber.org/zap"
 
 	"github.com/DataDog/datadog-agent/pkg/trace/pb"
+	"github.com/DataDog/opentelemetry-mapping-go/pkg/internal/sketchtest"
 	"github.com/DataDog/opentelemetry-mapping-go/pkg/quantile"
 )
 
@@ -438,5 +443,159 @@ func TestInfiniteBounds(t *testing.T) {
 			assert.Equal(t, sk.Basic.Max, p.Max())
 		})
 	}
+}
 
+// fromGoExpoHisto builds a delta exponential histogram from a go-expohisto.
+// Adapted from https://github.com/open-telemetry/opentelemetry-collector-contrib/commit/a2f9e1
+func fromGoExpoHisto(name string, agg *structure.Histogram[float64], startTime, timeNow time.Time) (md pmetric.Metrics) {
+	md = pmetric.NewMetrics()
+	nm := md.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+	nm.SetName(name)
+	expo := nm.SetEmptyExponentialHistogram()
+	expo.SetAggregationTemporality(pmetric.AggregationTemporalityDelta)
+
+	dp := expo.DataPoints().AppendEmpty()
+
+	dp.SetCount(agg.Count())
+	dp.SetSum(agg.Sum())
+	if agg.Count() != 0 {
+		dp.SetMin(agg.Min())
+		dp.SetMax(agg.Max())
+	}
+
+	dp.SetStartTimestamp(pcommon.NewTimestampFromTime(startTime))
+	dp.SetTimestamp(pcommon.NewTimestampFromTime(timeNow))
+
+	dp.SetZeroCount(agg.ZeroCount())
+	dp.SetScale(agg.Scale())
+
+	for _, half := range []struct {
+		inFunc  func() *structure.Buckets
+		outFunc func() pmetric.ExponentialHistogramDataPointBuckets
+	}{
+		{agg.Positive, dp.Positive},
+		{agg.Negative, dp.Negative},
+	} {
+		in := half.inFunc()
+		out := half.outFunc()
+		out.SetOffset(in.Offset())
+
+		out.BucketCounts().EnsureCapacity(int(in.Len()))
+
+		for i := uint32(0); i < in.Len(); i++ {
+			out.BucketCounts().Append(in.At(i))
+		}
+	}
+	return
+}
+
+// fromQuantile builds a delta exponential histogram from the quantile function of a known distribution.
+func fromQuantile(name string, startTime, timeNow time.Time, quantile sketchtest.QuantileFunction, N, M uint64) pmetric.Metrics {
+	agg := new(structure.Histogram[float64])
+	// Increase maximum size since contrast on test distributions can be big.
+	agg.Init(structure.NewConfig(structure.WithMaxSize(1_000)))
+	for i := 0; i <= int(N); i++ {
+		agg.UpdateByIncr(quantile(float64(i)/float64(N)), M)
+	}
+
+	return fromGoExpoHisto(name, agg, startTime, timeNow)
+}
+
+func TestKnownDistributionsQuantile(t *testing.T) {
+	timeNow := time.Now()
+	startTime := timeNow.Add(-10 * time.Second)
+	name := "example.histo"
+	const (
+		N uint64 = 1_000
+		M uint64 = 100
+	)
+
+	fN := float64(N)
+
+	// acceptableRelativeError for quantile estimation.
+	// Right now it is set to 4%. Anything below 5% is acceptable based on the SDK defaults.
+	// The relative error depends on the scale as well as the range of the distribution.
+	const acceptableRelativeError = 0.04
+
+	ctx := context.Background()
+	tr := newTranslator(t, zap.NewNop())
+
+	for _, tt := range []struct {
+		name     string
+		quantile sketchtest.QuantileFunction
+		// the map of quantiles for which the test is known to fail
+		excludedQuantiles map[int]struct{}
+	}{
+		{
+			name:     "Uniform distribution (a=0,b=N)",
+			quantile: sketchtest.UniformQ(0, fN),
+		},
+		{
+			name:     "Uniform distribution (a=-N,b=0)",
+			quantile: sketchtest.UniformQ(-fN, 0),
+		},
+		{
+			name:     "Uniform distribution (a=-N,b=N)",
+			quantile: sketchtest.UniformQ(-fN, fN),
+		},
+		{
+			name:     "U-quadratic distribution (a=0,b=N)",
+			quantile: sketchtest.UQuadraticQ(0, fN),
+		},
+		{
+			name:     "U-quadratic distribution (a=-N,b=0)",
+			quantile: sketchtest.UQuadraticQ(-fN, 0),
+			// Similar to the pkg/quantile tests, the p99 for this test fails, likely due to the shift of leftover bucket counts the right that is performed
+			// during the DDSketch -> quantile.Sketch conversion, causing the p99 of the output sketch to fall on 0
+			// (which means the InEpsilon check returns 1).
+			excludedQuantiles: map[int]struct{}{99: {}},
+		},
+		{
+			name:     "U-quadratic distribution (a=-N,b=N)",
+			quantile: sketchtest.UQuadraticQ(-fN/2, fN/2),
+		},
+		{
+			name:     "Truncated Exponential distribution (a=0,b=N,lambda=1/100)",
+			quantile: sketchtest.TruncateQ(0, fN, sketchtest.ExponentialQ(1.0/100), sketchtest.ExponentialCDF(1.0/100)),
+		},
+		{
+			name:     "Truncated Normal distribution (a=-8,b=8,mu=0, sigma=1e-3)",
+			quantile: sketchtest.TruncateQ(-8, 8, sketchtest.NormalQ(0, 1e-3), sketchtest.NormalCDF(0, 1e-3)),
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			md := fromQuantile(name, startTime, timeNow, tt.quantile, N, M)
+			consumer := &sketchConsumer{}
+			require.NoError(t, tr.MapMetrics(ctx, md, consumer))
+			require.NotNil(t, consumer.sk)
+
+			sketchConfig := quantile.Default()
+			for i := 0; i <= 100; i++ {
+				if _, ok := tt.excludedQuantiles[i]; ok {
+					// skip excluded quantile
+					continue
+				}
+				q := float64(i) / 100.0
+				expectedValue := tt.quantile(q)
+				quantileValue := consumer.sk.Quantile(sketchConfig, q)
+				if expectedValue == 0.0 {
+					// If the expected value is 0, we can't use InEpsilon, so we directly check that
+					// the value is equal (within a small float precision error margin).
+					assert.InDelta(
+						t,
+						expectedValue,
+						quantileValue,
+						2e-11,
+					)
+				} else {
+					assert.InEpsilon(t,
+						expectedValue,
+						quantileValue,
+						acceptableRelativeError,
+						fmt.Sprintf("error too high for p%d", i),
+					)
+				}
+			}
+		})
+	}
 }

--- a/pkg/quantile/go.mod
+++ b/pkg/quantile/go.mod
@@ -3,9 +3,10 @@ module github.com/DataDog/opentelemetry-mapping-go/pkg/quantile
 go 1.19
 
 require (
+	github.com/DataDog/opentelemetry-mapping-go/pkg/internal/sketchtest v0.0.0-00010101000000-000000000000
 	github.com/DataDog/sketches-go v1.4.1
 	github.com/dustin/go-humanize v1.0.0
-	github.com/stretchr/testify v1.8.1
+	github.com/stretchr/testify v1.8.2
 )
 
 require (
@@ -14,3 +15,5 @@ require (
 	google.golang.org/protobuf v1.28.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+replace github.com/DataDog/opentelemetry-mapping-go/pkg/internal/sketchtest => ../internal/sketchtest

--- a/pkg/quantile/go.sum
+++ b/pkg/quantile/go.sum
@@ -20,8 +20,8 @@ github.com/stretchr/objx v0.5.0/go.mod h1:Yh+to48EsGEfYuaHDzXPcE3xhTkx73EhmCGUpE
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.8.0/go.mod h1:yNjHg4UonilssWZ8iaSj1OCr/vHnekPRkoO+kdMU+MU=
-github.com/stretchr/testify v1.8.1 h1:w7B6lhMri9wdJUVmEZPGGhZzrYTPvgJArz7wNPgYKsk=
-github.com/stretchr/testify v1.8.1/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
+github.com/stretchr/testify v1.8.2 h1:+h33VjcLVPDHtOdpUCuF+7gSuG3yGIftsP1YvFihtJ8=
+github.com/stretchr/testify v1.8.2/go.mod h1:w2LPCIKwWwSfY2zedu0+kehJoqGctiVI29o6fzry7u4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 google.golang.org/protobuf v1.26.0-rc.1/go.mod h1:jlhhOSvTdKEhbULTjvd4ARK9grFBp09yW+WbY/TyQbw=

--- a/pkg/quantile/store_test.go
+++ b/pkg/quantile/store_test.go
@@ -6,8 +6,10 @@
 package quantile
 
 import (
+	"math"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -190,4 +192,31 @@ func TestStore(t *testing.T) {
 		}
 	})
 
+}
+
+func TestCols(t *testing.T) {
+	for _, tt := range []struct {
+		store string
+		k     []int32
+		n     []uint32
+	}{
+		{
+			store: "",
+		},
+		{
+			store: "0:1 1:1 2:2 3:1 4:1 5:1 8:1 9:1 10:max",
+			k:     []int32{0, 1, 2, 3, 4, 5, 8, 9, 10},
+			n:     []uint32{1, 1, 2, 1, 1, 1, 1, 1, math.MaxUint16},
+		},
+		{
+			store: "0:1 0:max",
+			k:     []int32{0, 0},
+			n:     []uint32{1, math.MaxUint16},
+		},
+	} {
+		st := buildStore(t, tt.store)
+		k, n := st.Cols()
+		assert.Equal(t, k, tt.k, "keys don't match")
+		assert.Equal(t, n, tt.n, "values don't match")
+	}
 }

--- a/versions.yaml
+++ b/versions.yaml
@@ -10,6 +10,7 @@ module-sets:
       - github.com/DataDog/opentelemetry-mapping-go/pkg/quantile
       - github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes
       - github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/metrics
+      - github.com/DataDog/opentelemetry-mapping-go/pkg/internal/sketchtest
 excluded-modules:
   - github.com/DataDog/opentelemetry-mapping-go/internal/tools
   - github.com/DataDog/opentelemetry-mapping-go/internal/tools/generate-license-file


### PR DESCRIPTION
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

The first few commits add some missing tests based on coverage:
   - Add min/max to tests about histograms
   - Add test with empty histogram
   - Add test with unsupported combination of options
   - Add test for Cols

The last two commits add a new `pkg/internal/sketchtest` module for defining common test helpers for tests in `pkg/quantile` and `pkg/otlp/metrics`. These helpers help define the [quantile function](https://en.wikipedia.org/wiki/Quantile_function) of different common distributions. In particular I added the (truncated) normal and exponential distributions to have more real-world looking tests (since I would expect both of these to be common in the wild). The naming of parameters is based on how they appear on Wikipedia.

I then use this new module to add more tests, notably one on `pkg/otlp/metrics` that tests the accuracy of the output `quantile.Sketch` from a given Exponential Histogram.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Improve our test coverage for histograms and make sure our mapping is sound.

