### PR TITLE
[pkg/otlp/attributes] Deprecate and replace functions which have usePreviewRules parameter.

### DIFF
--- a/.chloggen/mackjmr-deprecate-usePreviewRules.yaml
+++ b/.chloggen/mackjmr-deprecate-usePreviewRules.yaml
@@ -5,7 +5,7 @@ change_type: deprecation
 component: pkg/otlp/attributes
 
 # A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Deprecate and replace functions which have usePreviewRules parameter.
+note: Deprecate and replace functions which have usePreviewRules parameter in preparation to graduate the exporter.datadog.hostname.preview feature gate to stable.
 
 # The PR related to this change
 issues: [21]

--- a/.chloggen/mackjmr-deprecate-usePreviewRules.yaml
+++ b/.chloggen/mackjmr-deprecate-usePreviewRules.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation
+
+# The name of the component (e.g. pkg/quantile)
+component: pkg/otlp/attributes
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Deprecate and replace functions which have usePreviewRules parameter.
+
+# The PR related to this change
+issues: [21]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/mackjmr-deprecate-usePreviewRules.yaml
+++ b/.chloggen/mackjmr-deprecate-usePreviewRules.yaml
@@ -9,8 +9,3 @@ note: Deprecate and replace functions which have usePreviewRules parameter.
 
 # The PR related to this change
 issues: [21]
-
-# (Optional) One or more lines of additional information to render under the primary note.
-# These lines will be padded with 2 spaces and then inserted directly into the document.
-# Use pipe (|) for multiline entries.
-subtext:

--- a/pkg/otlp/attributes/azure/azure.go
+++ b/pkg/otlp/attributes/azure/azure.go
@@ -31,8 +31,9 @@ type HostInfo struct {
 	HostAliases []string
 }
 
-// HostInfoFromAttributes gets Azure host info from attributes following
-// OpenTelemetry semantic conventions
+// HostInfoFromAttributes gets Azure host info from attributes following OpenTelemetry
+// semantic conventions.
+// Deprecated: AttributeHostID will be used as the hostname once the preview rule is stable.
 func HostInfoFromAttributes(attrs pcommon.Map, usePreviewRules bool) (hostInfo *HostInfo) {
 	hostInfo = &HostInfo{}
 
@@ -44,7 +45,22 @@ func HostInfoFromAttributes(attrs pcommon.Map, usePreviewRules bool) (hostInfo *
 	return
 }
 
-// HostnameFromAttributes gets the Azure hostname from attributes
+// HostnameFromAttrs gets the Azure hostname from attributes.
+func HostnameFromAttrs(attrs pcommon.Map) (string, bool) {
+	if vmID, ok := attrs.Get(conventions.AttributeHostID); ok {
+		return vmID.Str(), true
+	}
+
+	if hostname, ok := attrs.Get(conventions.AttributeHostName); ok {
+		return hostname.Str(), true
+	}
+
+	return "", false
+}
+
+// HostnameFromAttributes gets the Azure hostname from attributes.
+// Deprecated: HostnameFromAttributes is deprecated in favor of HostnameFromAttrs which removes parameter
+// usePreviewRules.
 func HostnameFromAttributes(attrs pcommon.Map, usePreviewRules bool) (string, bool) {
 	if vmID, ok := attrs.Get(conventions.AttributeHostID); usePreviewRules && ok {
 		return vmID.Str(), true

--- a/pkg/otlp/attributes/azure/azure_test.go
+++ b/pkg/otlp/attributes/azure/azure_test.go
@@ -111,3 +111,45 @@ func TestClusterNameFromAttributes(t *testing.T) {
 	_, ok = ClusterNameFromAttributes(testutils.NewAttributeMap(map[string]string{}))
 	assert.False(t, ok)
 }
+
+func TestHostnameFromAttrs(t *testing.T) {
+	tests := []struct {
+		name  string
+		attrs pcommon.Map
+
+		ok       bool
+		hostname string
+	}{
+		{
+			name:  "all attributes",
+			attrs: testAttrs,
+
+			ok:       true,
+			hostname: testVMID,
+		},
+		{
+			name: "no host id",
+			attrs: testutils.NewAttributeMap(map[string]string{
+				conventions.AttributeCloudProvider: conventions.AttributeCloudProviderAzure,
+				conventions.AttributeHostName:      testHostname,
+			}),
+			ok:       true,
+			hostname: testHostname,
+		},
+		{
+			name:  "empty",
+			attrs: testEmpty,
+		},
+	}
+
+	for _, testInstance := range tests {
+		t.Run(testInstance.name, func(t *testing.T) {
+			hostname, ok := HostnameFromAttrs(testInstance.attrs)
+
+			assert.Equal(t, testInstance.ok, ok)
+			if testInstance.ok || ok {
+				assert.Equal(t, testInstance.hostname, hostname)
+			}
+		})
+	}
+}

--- a/pkg/otlp/attributes/ec2/ec2.go
+++ b/pkg/otlp/attributes/ec2/ec2.go
@@ -46,8 +46,10 @@ func isDefaultHostname(hostname string) bool {
 	return false
 }
 
-// HostnameFromAttributes gets a valid hostname from labels
-// if available
+// HostnameFromAttributes gets a valid hostname from labels if
+// available.
+// Deprecated: HostnameFromAttributes is deprecated in favor of
+// HostnameFromAttrs which removes parameter usePreviewRules.
 func HostnameFromAttributes(attrs pcommon.Map, usePreviewRules bool) (string, bool) {
 	hostName, ok := attrs.Get(conventions.AttributeHostName)
 	// With hostname preview rules, return the EC2 instance id always.
@@ -55,6 +57,16 @@ func HostnameFromAttributes(attrs pcommon.Map, usePreviewRules bool) (string, bo
 		return hostName.Str(), true
 	}
 
+	if hostID, ok := attrs.Get(conventions.AttributeHostID); ok {
+		return hostID.Str(), true
+	}
+
+	return "", false
+}
+
+// HostnameFromAttrs gets a valid hostname from labels
+// if available
+func HostnameFromAttrs(attrs pcommon.Map) (string, bool) {
 	if hostID, ok := attrs.Get(conventions.AttributeHostID); ok {
 		return hostID.Str(), true
 	}

--- a/pkg/otlp/attributes/ec2/ec2_test.go
+++ b/pkg/otlp/attributes/ec2/ec2_test.go
@@ -53,6 +53,29 @@ func TestHostnameFromAttributes(t *testing.T) {
 	assert.Equal(t, hostname, testInstanceID)
 }
 
+func TestHostnameFromAttrs(t *testing.T) {
+	t.Run("host id", func(t *testing.T) {
+		attrs := testutils.NewAttributeMap(map[string]string{
+			conventions.AttributeCloudProvider: conventions.AttributeCloudProviderAWS,
+			conventions.AttributeHostID:        testInstanceID,
+			conventions.AttributeHostName:      testIP,
+		})
+		hostname, ok := HostnameFromAttrs(attrs)
+		assert.True(t, ok)
+		assert.Equal(t, hostname, testInstanceID)
+	})
+
+	t.Run("no host id", func(t *testing.T) {
+		attrs := testutils.NewAttributeMap(map[string]string{
+			conventions.AttributeCloudProvider: conventions.AttributeCloudProviderAWS,
+			conventions.AttributeHostName:      testIP,
+		})
+		hostname, ok := HostnameFromAttrs(attrs)
+		assert.False(t, ok)
+		assert.Equal(t, hostname, "")
+	})
+}
+
 func TestHostInfoFromAttributes(t *testing.T) {
 	attrs := testutils.NewAttributeMap(map[string]string{
 		conventions.AttributeCloudProvider: conventions.AttributeCloudProviderAWS,

--- a/pkg/otlp/attributes/gcp/gcp.go
+++ b/pkg/otlp/attributes/gcp/gcp.go
@@ -53,7 +53,9 @@ func getGCPIntegrationHostname(attrs pcommon.Map) (string, bool) {
 }
 
 // HostnameFromAttributes gets a valid hostname from labels
-// if available
+// if available.
+// Deprecated: HostnameFromAttributes is deprecated in favor of
+// HostnameFromAttrs which removes parameter usePreviewRules.
 func HostnameFromAttributes(attrs pcommon.Map, usePreviewRules bool) (string, bool) {
 	if usePreviewRules {
 		return getGCPIntegrationHostname(attrs)
@@ -66,8 +68,16 @@ func HostnameFromAttributes(attrs pcommon.Map, usePreviewRules bool) (string, bo
 	return "", false
 }
 
+// HostnameFromAttrs gets a valid hostname from labels
+// if available.
+func HostnameFromAttrs(attrs pcommon.Map) (string, bool) {
+	return getGCPIntegrationHostname(attrs)
+}
+
 // HostInfoFromAttributes gets GCP host info from attributes following
-// OpenTelemetry semantic conventions
+// OpenTelemetry semantic conventions.
+// Deprecated: HostInfoFromAttributes is deprecated in favor of
+// HostInfoFromAttrs which removes parameter usePreviewRules.
 func HostInfoFromAttributes(attrs pcommon.Map, usePreviewRules bool) (hostInfo *HostInfo) {
 	hostInfo = &HostInfo{}
 
@@ -89,6 +99,30 @@ func HostInfoFromAttributes(attrs pcommon.Map, usePreviewRules bool) (hostInfo *
 
 	if alias, ok := getGCPIntegrationHostname(attrs); ok && !usePreviewRules {
 		hostInfo.HostAliases = append(hostInfo.HostAliases, alias)
+	}
+
+	return
+}
+
+// HostInfoFromAttrs gets GCP host info from attributes following
+// OpenTelemetry semantic conventions
+func HostInfoFromAttrs(attrs pcommon.Map) (hostInfo *HostInfo) {
+	hostInfo = &HostInfo{}
+
+	if hostID, ok := attrs.Get(conventions.AttributeHostID); ok {
+		hostInfo.GCPTags = append(hostInfo.GCPTags, fmt.Sprintf("instance-id:%s", hostID.Str()))
+	}
+
+	if cloudZone, ok := attrs.Get(conventions.AttributeCloudAvailabilityZone); ok {
+		hostInfo.GCPTags = append(hostInfo.GCPTags, fmt.Sprintf("zone:%s", cloudZone.Str()))
+	}
+
+	if hostType, ok := attrs.Get(conventions.AttributeHostType); ok {
+		hostInfo.GCPTags = append(hostInfo.GCPTags, fmt.Sprintf("instance-type:%s", hostType.Str()))
+	}
+
+	if cloudAccount, ok := attrs.Get(conventions.AttributeCloudAccountID); ok {
+		hostInfo.GCPTags = append(hostInfo.GCPTags, fmt.Sprintf("project:%s", cloudAccount.Str()))
 	}
 
 	return


### PR DESCRIPTION
### What does this PR do?
This PR marks the exported functions which use the `usePreviewRules` parameter as deprecated, and adds new replacement functions without parameter `usePreviewRules`.

This is the first step to graduate the `exporter.datadog.hostname.preview` feature gate to stable.

Once this change is released, the next steps are:
- Marking the `exporter.datadog.hostname.preview` feature gate as stable (cannot remove it completely yet -- see [issue](https://github.com/open-telemetry/opentelemetry-collector/issues/7044)) and replace deprecated functions calls by new function calls in `opentelemetry-collector-contrib` and `datadog-agent`.
- Remove deprecated functions and codepaths which use preview rules in `opentelemetry-mapping-go`.
- [optional] Rename functions to original name following approach [here](https://github.com/open-telemetry/opentelemetry-collector/blob/main/CONTRIBUTING.md#example-3---changing-the-arguments-of-a-function).

### Motivation
https://datadoghq.atlassian.net/browse/OTEL-231

