### PR TITLE
[pkg/otlp/metrics] Send min and max metrics for delta histograms; rename option to send aggregations

### DIFF
--- a/.chloggen/mx-psi_min-max-metrics1.yaml
+++ b/.chloggen/mx-psi_min-max-metrics1.yaml
@@ -11,6 +11,9 @@ note: Deprecate metrics.WithCountSumMetrics translator option.
 issues: [23]
 
 # (Optional) One or more lines of additional information to render under the primary note.
+
 # These lines will be padded with 2 spaces and then inserted directly into the document.
 # Use pipe (|) for multiline entries.
-subtext: Use metrics.WithHistogramAggregations instead.
+subtext: | 
+  - metrics.WithCountSumMetrics will now send min and max metrics when available.
+  - Use metrics.WithHistogramAggregations instead.

--- a/.chloggen/mx-psi_min-max-metrics1.yaml
+++ b/.chloggen/mx-psi_min-max-metrics1.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: deprecation 
+
+# The name of the component (e.g. pkg/quantile)
+component: pkg/otlp/metrics
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Deprecate metrics.WithCountSumMetrics translator option.
+
+# The PR related to this change
+issues: [23]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: Use metrics.WithHistogramAggregations instead.

--- a/.chloggen/mx-psi_min-max-metrics2.yaml
+++ b/.chloggen/mx-psi_min-max-metrics2.yaml
@@ -1,0 +1,11 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement 
+
+# The name of the component (e.g. pkg/quantile)
+component: pkg/otlp/metrics
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Send min and max for delta histograms and delta exponential histograms when metrics.WithHistogramAggregations is used.
+
+# The PR related to this change
+issues: [23]

--- a/pkg/otlp/metrics/config.go
+++ b/pkg/otlp/metrics/config.go
@@ -22,11 +22,11 @@ import (
 
 type translatorConfig struct {
 	// metrics export behavior
-	HistMode                 HistogramMode
-	SendCountSum             bool
-	Quantiles                bool
-	SendMonotonic            bool
-	ResourceAttributesAsTags bool
+	HistMode                  HistogramMode
+	SendHistogramAggregations bool
+	Quantiles                 bool
+	SendMonotonic             bool
+	ResourceAttributesAsTags  bool
 	// Deprecated: use InstrumentationScopeMetadataAsTags instead in favor of
 	// https://github.com/open-telemetry/opentelemetry-proto/releases/tag/v0.15.0
 	// Both must not be enabled at the same time.
@@ -138,9 +138,15 @@ func WithHistogramMode(mode HistogramMode) TranslatorOption {
 }
 
 // WithCountSumMetrics exports .count and .sum histogram metrics.
+// Deprecated: Use WithHistogramAggregations instead.
 func WithCountSumMetrics() TranslatorOption {
+	return WithHistogramAggregations()
+}
+
+// WithHistogramAggregations exports .count, .sum, .min and .max histogram metrics when available.
+func WithHistogramAggregations() TranslatorOption {
 	return func(t *translatorConfig) error {
-		t.SendCountSum = true
+		t.SendHistogramAggregations = true
 		return nil
 	}
 }

--- a/pkg/otlp/metrics/histograms_test.go
+++ b/pkg/otlp/metrics/histograms_test.go
@@ -37,7 +37,7 @@ func TestDeltaHistogramTranslatorOptions(t *testing.T) {
 			ddogfile: "testdata/datadogdata/histogram/simple-delta_dist-cs.json",
 			options: []TranslatorOption{
 				WithHistogramMode(HistogramModeDistributions),
-				WithCountSumMetrics(),
+				WithHistogramAggregations(),
 			},
 		},
 		{
@@ -54,7 +54,7 @@ func TestDeltaHistogramTranslatorOptions(t *testing.T) {
 			ddogfile: "testdata/datadogdata/histogram/simple-delta_counters-cs.json",
 			options: []TranslatorOption{
 				WithHistogramMode(HistogramModeCounters),
-				WithCountSumMetrics(),
+				WithHistogramAggregations(),
 			},
 		},
 		{
@@ -63,7 +63,7 @@ func TestDeltaHistogramTranslatorOptions(t *testing.T) {
 			ddogfile: "testdata/datadogdata/histogram/simple-delta_nobuckets-cs.json",
 			options: []TranslatorOption{
 				WithHistogramMode(HistogramModeNoBuckets),
-				WithCountSumMetrics(),
+				WithHistogramAggregations(),
 			},
 		},
 		{
@@ -109,7 +109,7 @@ func TestCumulativeHistogramTranslatorOptions(t *testing.T) {
 			ddogfile: "testdata/datadogdata/histogram/simple-cumulative_dist-cs.json",
 			options: []TranslatorOption{
 				WithHistogramMode(HistogramModeDistributions),
-				WithCountSumMetrics(),
+				WithHistogramAggregations(),
 			},
 		},
 		{
@@ -126,7 +126,7 @@ func TestCumulativeHistogramTranslatorOptions(t *testing.T) {
 			ddogfile: "testdata/datadogdata/histogram/simple-cumulative_counters-cs.json",
 			options: []TranslatorOption{
 				WithHistogramMode(HistogramModeCounters),
-				WithCountSumMetrics(),
+				WithHistogramAggregations(),
 			},
 		},
 		{
@@ -135,7 +135,7 @@ func TestCumulativeHistogramTranslatorOptions(t *testing.T) {
 			ddogfile: "testdata/datadogdata/histogram/simple-cumulative_nobuckets-cs.json",
 			options: []TranslatorOption{
 				WithHistogramMode(HistogramModeNoBuckets),
-				WithCountSumMetrics(),
+				WithHistogramAggregations(),
 			},
 		},
 	}
@@ -180,7 +180,7 @@ func TestExponentialHistogramTranslatorOptions(t *testing.T) {
 			otlpfile: "testdata/otlpdata/histogram/simple-exponential.json",
 			ddogfile: "testdata/datadogdata/histogram/simple-exponential_cs.json",
 			options: []TranslatorOption{
-				WithCountSumMetrics(),
+				WithHistogramAggregations(),
 			},
 			expectedUnknownMetricType:                 1,
 			expectedUnsupportedAggregationTemporality: 1,
@@ -210,7 +210,7 @@ func TestExponentialHistogramTranslatorOptions(t *testing.T) {
 			otlpfile: "testdata/otlpdata/histogram/simple-exponential.json",
 			ddogfile: "testdata/datadogdata/histogram/simple-exponential_cs-ilmd-tags.json",
 			options: []TranslatorOption{
-				WithCountSumMetrics(),
+				WithHistogramAggregations(),
 				WithInstrumentationLibraryMetadataAsTags(),
 			},
 			expectedUnknownMetricType:                 1,
@@ -232,7 +232,7 @@ func TestExponentialHistogramTranslatorOptions(t *testing.T) {
 			otlpfile: "testdata/otlpdata/histogram/simple-exponential.json",
 			ddogfile: "testdata/datadogdata/histogram/simple-exponential_cs-both-tags.json",
 			options: []TranslatorOption{
-				WithCountSumMetrics(),
+				WithHistogramAggregations(),
 				WithResourceAttributesAsTags(),
 				WithInstrumentationLibraryMetadataAsTags(),
 			},
@@ -244,7 +244,7 @@ func TestExponentialHistogramTranslatorOptions(t *testing.T) {
 			otlpfile: "testdata/otlpdata/histogram/simple-exponential.json",
 			ddogfile: "testdata/datadogdata/histogram/simple-exponential_all.json",
 			options: []TranslatorOption{
-				WithCountSumMetrics(),
+				WithHistogramAggregations(),
 				WithResourceAttributesAsTags(),
 				WithInstrumentationLibraryMetadataAsTags(),
 				WithInstrumentationScopeMetadataAsTags(),

--- a/pkg/otlp/metrics/mixed_metrics_test.go
+++ b/pkg/otlp/metrics/mixed_metrics_test.go
@@ -46,7 +46,7 @@ func TestMapMetrics(t *testing.T) {
 			otlpfile: "testdata/otlpdata/mixed/simple.json",
 			ddogfile: "testdata/datadogdata/mixed/simple_cs.json",
 			options: []TranslatorOption{
-				WithCountSumMetrics(),
+				WithHistogramAggregations(),
 			},
 			expectedUnknownMetricType:                 1,
 			expectedUnsupportedAggregationTemporality: 2,
@@ -76,7 +76,7 @@ func TestMapMetrics(t *testing.T) {
 			otlpfile: "testdata/otlpdata/mixed/simple.json",
 			ddogfile: "testdata/datadogdata/mixed/simple_cs-ilmd-tags.json",
 			options: []TranslatorOption{
-				WithCountSumMetrics(),
+				WithHistogramAggregations(),
 				WithInstrumentationLibraryMetadataAsTags(),
 			},
 			expectedUnknownMetricType:                 1,
@@ -98,7 +98,7 @@ func TestMapMetrics(t *testing.T) {
 			otlpfile: "testdata/otlpdata/mixed/simple.json",
 			ddogfile: "testdata/datadogdata/mixed/simple_cs-both-tags.json",
 			options: []TranslatorOption{
-				WithCountSumMetrics(),
+				WithHistogramAggregations(),
 				WithResourceAttributesAsTags(),
 				WithInstrumentationLibraryMetadataAsTags(),
 			},
@@ -110,7 +110,7 @@ func TestMapMetrics(t *testing.T) {
 			otlpfile: "testdata/otlpdata/mixed/simple.json",
 			ddogfile: "testdata/datadogdata/mixed/simple_all.json",
 			options: []TranslatorOption{
-				WithCountSumMetrics(),
+				WithHistogramAggregations(),
 				WithResourceAttributesAsTags(),
 				WithInstrumentationLibraryMetadataAsTags(),
 				WithInstrumentationScopeMetadataAsTags(),

--- a/pkg/otlp/metrics/testdata/datadogdata/histogram/simple-delta_counters-cs.json
+++ b/pkg/otlp/metrics/testdata/datadogdata/histogram/simple-delta_counters-cs.json
@@ -24,6 +24,28 @@
       "Value": 3.141592653589793
     },
     {
+      "Name": "doubleHist.test.min",
+      "Tags": [
+        "attribute_tag:attribute_value"
+      ],
+      "Host": "hostname",
+      "OriginID": "",
+      "Type": "gauge",
+      "Timestamp": 1667560641226420924,
+      "Value": -100
+    },
+    {
+      "Name": "doubleHist.test.max",
+      "Tags": [
+        "attribute_tag:attribute_value"
+      ],
+      "Host": "hostname",
+      "OriginID": "",
+      "Type": "gauge",
+      "Timestamp": 1667560641226420924,
+      "Value": 100
+    },
+    {
       "Name": "doubleHist.test.bucket",
       "Tags": [
         "lower_bound:-inf",

--- a/pkg/otlp/metrics/testdata/datadogdata/histogram/simple-delta_dist-cs.json
+++ b/pkg/otlp/metrics/testdata/datadogdata/histogram/simple-delta_dist-cs.json
@@ -45,6 +45,28 @@
       "Type": "count",
       "Timestamp": 1667560641226420924,
       "Value": 3.141592653589793
+    },
+    {
+      "Name": "doubleHist.test.min",
+      "Tags": [
+        "attribute_tag:attribute_value"
+      ],
+      "Host": "hostname",
+      "OriginID": "",
+      "Type": "gauge",
+      "Timestamp": 1667560641226420924,
+      "Value": -100
+    },
+    {
+      "Name": "doubleHist.test.max",
+      "Tags": [
+        "attribute_tag:attribute_value"
+      ],
+      "Host": "hostname",
+      "OriginID": "",
+      "Type": "gauge",
+      "Timestamp": 1667560641226420924,
+      "Value": 100
     }
   ]
 }

--- a/pkg/otlp/metrics/testdata/datadogdata/histogram/simple-delta_nobuckets-cs.json
+++ b/pkg/otlp/metrics/testdata/datadogdata/histogram/simple-delta_nobuckets-cs.json
@@ -22,6 +22,28 @@
       "Type": "count",
       "Timestamp": 1667560641226420924,
       "Value": 3.141592653589793
+    },
+    {
+      "Name": "doubleHist.test.min",
+      "Tags": [
+        "attribute_tag:attribute_value"
+      ],
+      "Host": "hostname",
+      "OriginID": "",
+      "Type": "gauge",
+      "Timestamp": 1667560641226420924,
+      "Value": -100
+    },
+    {
+      "Name": "doubleHist.test.max",
+      "Tags": [
+        "attribute_tag:attribute_value"
+      ],
+      "Host": "hostname",
+      "OriginID": "",
+      "Type": "gauge",
+      "Timestamp": 1667560641226420924,
+      "Value": 100
     }
   ]
 }

--- a/pkg/otlp/metrics/testdata/datadogdata/histogram/simple-exponential_all.json
+++ b/pkg/otlp/metrics/testdata/datadogdata/histogram/simple-exponential_all.json
@@ -70,6 +70,34 @@
       "Type": "count",
       "Timestamp": 1667560641226420924,
       "Value": 3.141592653589793
+    },
+    {
+      "Name": "double.exponential.delta.histogram.min",
+      "Tags": [
+        "custom_attribute:custom_value",
+        "deployment.environment:dev",
+        "instrumentation_scope:foo",
+        "instrumentation_scope_version:1.0.0"
+      ],
+      "Host": "res-hostname",
+      "OriginID": "",
+      "Type": "gauge",
+      "Timestamp": 1667560641226420924,
+      "Value": -100000
+    },
+    {
+      "Name": "double.exponential.delta.histogram.max",
+      "Tags": [
+        "custom_attribute:custom_value",
+        "deployment.environment:dev",
+        "instrumentation_scope:foo",
+        "instrumentation_scope_version:1.0.0"
+      ],
+      "Host": "res-hostname",
+      "OriginID": "",
+      "Type": "gauge",
+      "Timestamp": 1667560641226420924,
+      "Value": 100000
     }
   ]
 }

--- a/pkg/otlp/metrics/testdata/datadogdata/histogram/simple-exponential_cs-both-tags.json
+++ b/pkg/otlp/metrics/testdata/datadogdata/histogram/simple-exponential_cs-both-tags.json
@@ -70,6 +70,34 @@
       "Type": "count",
       "Timestamp": 1667560641226420924,
       "Value": 3.141592653589793
+    },
+    {
+      "Name": "double.exponential.delta.histogram.min",
+      "Tags": [
+        "custom_attribute:custom_value",
+        "deployment.environment:dev",
+        "instrumentation_library:foo",
+        "instrumentation_library_version:1.0.0"
+      ],
+      "Host": "res-hostname",
+      "OriginID": "",
+      "Type": "gauge",
+      "Timestamp": 1667560641226420924,
+      "Value": -100000
+    },
+    {
+      "Name": "double.exponential.delta.histogram.max",
+      "Tags": [
+        "custom_attribute:custom_value",
+        "deployment.environment:dev",
+        "instrumentation_library:foo",
+        "instrumentation_library_version:1.0.0"
+      ],
+      "Host": "res-hostname",
+      "OriginID": "",
+      "Type": "gauge",
+      "Timestamp": 1667560641226420924,
+      "Value": 100000
     }
   ]
 }

--- a/pkg/otlp/metrics/testdata/datadogdata/histogram/simple-exponential_cs-ilmd-tags.json
+++ b/pkg/otlp/metrics/testdata/datadogdata/histogram/simple-exponential_cs-ilmd-tags.json
@@ -70,6 +70,34 @@
       "Type": "count",
       "Timestamp": 1667560641226420924,
       "Value": 3.141592653589793
+    },
+    {
+      "Name": "double.exponential.delta.histogram.min",
+      "Tags": [
+        "custom_attribute:custom_value",
+        "deployment.environment:dev",
+        "instrumentation_library:foo",
+        "instrumentation_library_version:1.0.0"
+      ],
+      "Host": "res-hostname",
+      "OriginID": "",
+      "Type": "gauge",
+      "Timestamp": 1667560641226420924,
+      "Value": -100000
+    },
+    {
+      "Name": "double.exponential.delta.histogram.max",
+      "Tags": [
+        "custom_attribute:custom_value",
+        "deployment.environment:dev",
+        "instrumentation_library:foo",
+        "instrumentation_library_version:1.0.0"
+      ],
+      "Host": "res-hostname",
+      "OriginID": "",
+      "Type": "gauge",
+      "Timestamp": 1667560641226420924,
+      "Value": 100000
     }
   ]
 }

--- a/pkg/otlp/metrics/testdata/datadogdata/histogram/simple-exponential_cs.json
+++ b/pkg/otlp/metrics/testdata/datadogdata/histogram/simple-exponential_cs.json
@@ -1,69 +1,93 @@
 {
-    "Sketches": [
-      {
-        "Name": "double.exponential.delta.histogram",
-        "Tags": [
-          "custom_attribute:custom_value",
-          "deployment.environment:dev"
-        ],
-        "Host": "res-hostname",
-        "OriginID": "",
-        "Timestamp": 1667560641226420924,
-        "Summary": {
-          "Min": -100000,
-          "Max": 100000,
-          "Sum": 3.141592653589793,
-          "Avg": 0.10471975511965977,
-          "Cnt": 30
-        },
-        "Keys": [
-          -1341,
-          -1340,
-          -1339,
-          0,
-          1340,
-          1341,
-          1342,
-          1343,
-          1344
-        ],
-        "Counts": [
-          5,
-          4,
-          1,
-          10,
-          0,
-          2,
-          1,
-          3,
-          4
-        ]
-      }
-    ],
-    "TimeSeries": [
-      {
-        "Name": "double.exponential.delta.histogram.count",
-        "Tags": [
-          "custom_attribute:custom_value",
-          "deployment.environment:dev"
-        ],
-        "Host": "res-hostname",
-        "OriginID": "",
-        "Type": "count",
-        "Timestamp": 1667560641226420924,
-        "Value": 30
+  "Sketches": [
+    {
+      "Name": "double.exponential.delta.histogram",
+      "Tags": [
+        "custom_attribute:custom_value",
+        "deployment.environment:dev"
+      ],
+      "Host": "res-hostname",
+      "OriginID": "",
+      "Timestamp": 1667560641226420924,
+      "Summary": {
+        "Min": -100000,
+        "Max": 100000,
+        "Sum": 3.141592653589793,
+        "Avg": 0.10471975511965977,
+        "Cnt": 30
       },
-      {
-        "Name": "double.exponential.delta.histogram.sum",
-        "Tags": [
-          "custom_attribute:custom_value",
-          "deployment.environment:dev"
-        ],
-        "Host": "res-hostname",
-        "OriginID": "",
-        "Type": "count",
-        "Timestamp": 1667560641226420924,
-        "Value": 3.141592653589793
-      }
-    ]
-  }
+      "Keys": [
+        -1341,
+        -1340,
+        -1339,
+        0,
+        1340,
+        1341,
+        1342,
+        1343,
+        1344
+      ],
+      "Counts": [
+        5,
+        4,
+        1,
+        10,
+        0,
+        2,
+        1,
+        3,
+        4
+      ]
+    }
+  ],
+  "TimeSeries": [
+    {
+      "Name": "double.exponential.delta.histogram.count",
+      "Tags": [
+        "custom_attribute:custom_value",
+        "deployment.environment:dev"
+      ],
+      "Host": "res-hostname",
+      "OriginID": "",
+      "Type": "count",
+      "Timestamp": 1667560641226420924,
+      "Value": 30
+    },
+    {
+      "Name": "double.exponential.delta.histogram.sum",
+      "Tags": [
+        "custom_attribute:custom_value",
+        "deployment.environment:dev"
+      ],
+      "Host": "res-hostname",
+      "OriginID": "",
+      "Type": "count",
+      "Timestamp": 1667560641226420924,
+      "Value": 3.141592653589793
+    },
+    {
+      "Name": "double.exponential.delta.histogram.min",
+      "Tags": [
+        "custom_attribute:custom_value",
+        "deployment.environment:dev"
+      ],
+      "Host": "res-hostname",
+      "OriginID": "",
+      "Type": "gauge",
+      "Timestamp": 1667560641226420924,
+      "Value": -100000
+    },
+    {
+      "Name": "double.exponential.delta.histogram.max",
+      "Tags": [
+        "custom_attribute:custom_value",
+        "deployment.environment:dev"
+      ],
+      "Host": "res-hostname",
+      "OriginID": "",
+      "Type": "gauge",
+      "Timestamp": 1667560641226420924,
+      "Value": 100000
+    }
+  ]
+}


### PR DESCRIPTION
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

- Send min and max histogram aggregations for delta histograms and delta exponential histograms when using the `metrics.WithHistogramAggregations` option.
- Deprecate `metrics.WithSumCountMetrics` in favor of `metrics.WithHistogramAggregations`

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Allow backend to leverage these values when available.
