### PR TITLE
Add apidiff CI check

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,6 +5,7 @@ on:
     tags:
       - "v[0-9]+.[0-9]+.[0-9]+*"
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref }}
@@ -95,3 +96,49 @@ jobs:
         run: make gen-licenses && git diff -s --exit-code || (echo "make gen-licenses needed"; exit 1)
       - name: Check golangci-lint
         run: make lint
+
+  breaking-changes:
+    runs-on: ubuntu-latest
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'breaking-change')}}
+    needs: [setup-environment]
+    steps:
+      - name: Checkout base branch
+        uses: actions/checkout@v3
+        with: 
+          ref: ${{ github.base_ref }}
+          path: ${{ github.base_ref }}
+
+      - name: Checkout HEAD
+        uses: actions/checkout@v3
+        with: 
+          ref: ${{ github.head_ref }}
+          path: ${{ github.head_ref }}
+
+      - name: Cache Go
+        id: go-cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/go/bin
+            ~/go/pkg/mod
+          key: go-cache-${{ runner.os }}-${{ hashFiles('**/go.sum') }}-${{ hashFiles('internal/tools/**') }}
+
+      - name: Setup Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: 1.19
+
+      - name: Install tools
+        run: |
+          cd ${{ github.head_ref }}
+          make install-tools
+
+      - name: Generate-States
+        run: |
+          cd ${{ github.base_ref }}
+          make apidiff-generate APIHEADERS=~/apidiff-data
+          
+      - name: Compare-States
+        run: |
+          cd ${{ github.head_ref }}
+          make apidiff-compare APIHEADERS=~/apidiff-data

--- a/Makefile
+++ b/Makefile
@@ -69,12 +69,12 @@ APIHEADERS := internal/apidiff-data
 
 .PHONY: apidiff-generate
 apidiff-generate:
-	for mod in $(GOMODULES); do \
+	set -e; for mod in $(GOMODULES); do \
 		./internal/scripts/apidiff-generate.sh $$mod $(APIHEADERS); \
 	done
 
 .PHONY: apidiff-compare
 apidiff-compare:
-	for mod in $(GOMODULES); do \
+	set -e; for mod in $(GOMODULES); do \
 		./internal/scripts/apidiff-compare.sh $$mod $(APIHEADERS); \
 	done

--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/golangci/golangci-lint v1.52.2
 	go.opentelemetry.io/build-tools/chloggen v0.6.0
 	go.opentelemetry.io/build-tools/multimod v0.6.0
-	golang.org/x/exp v0.0.0-20230321023759-10a507213a29
+	golang.org/x/exp v0.0.0-20230321023759-10a507213a29 // No tagged version available
 )
 
 require (


### PR DESCRIPTION
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Add CI check to check for breaking changes. You can see it in action in #47. If a breaking change happens, the CI check will fal. The CI check can be skipped by adding the `breaking-change` label.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Ensure that we catch breaking changes automatically and we follow the deprecation process (see #1)
