### PR TITLE
[pkg/otlp/metrics] Deprecate and remove usage of WithPreviewHostnameFromAttributes

### DIFF
--- a/pkg/otlp/metrics/config.go
+++ b/pkg/otlp/metrics/config.go
@@ -37,9 +37,7 @@ type translatorConfig struct {
 	sweepInterval int64
 	deltaTTL      int64
 
-	// hostname provider configuration
-	previewHostnameFromAttributes bool
-	fallbackSourceProvider        source.Provider
+	fallbackSourceProvider source.Provider
 }
 
 // TranslatorOption is a translator creation option.
@@ -71,9 +69,10 @@ func WithFallbackSourceProvider(provider source.Provider) TranslatorOption {
 }
 
 // WithPreviewHostnameFromAttributes enables the preview hostname algorithm.
+//
+// Deprecated: The hostname preview is always enabled. This is a no-op.
 func WithPreviewHostnameFromAttributes() TranslatorOption {
 	return func(t *translatorConfig) error {
-		t.previewHostnameFromAttributes = true
 		return nil
 	}
 }

--- a/pkg/otlp/metrics/metrics_translator.go
+++ b/pkg/otlp/metrics/metrics_translator.go
@@ -495,7 +495,7 @@ func (t *Translator) mapSummaryMetrics(
 }
 
 func (t *Translator) source(m pcommon.Map) (source.Source, error) {
-	src, ok := attributes.SourceFromAttributes(m, t.cfg.previewHostnameFromAttributes)
+	src, ok := attributes.SourceFromAttrs(m)
 	if !ok {
 		var err error
 		src, err = t.cfg.fallbackSourceProvider.Source(context.Background())


### PR DESCRIPTION
### What does this PR do?

This PR deprecates and remove usage of WithPreviewHostnameFromAttributes by making the hostname preview always enabled. Once the changes in this PR are released, usage of this function in the [agent](https://github.com/DataDog/datadog-agent/blob/7.42.x/pkg/otlp/internal/serializerexporter/exporter.go#L94) and [collector](https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/v0.75.0/exporter/datadogexporter/metrics_exporter.go#L94) will be removed.
### Motivation
https://datadoghq.atlassian.net/browse/OTEL-231

