### PR TITLE
Fix breaking changes workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -99,7 +99,7 @@ jobs:
 
   breaking-changes:
     runs-on: ubuntu-latest
-    if: ${{ !contains(github.event.pull_request.labels.*.name, 'breaking-change')}}
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'breaking-change') && github.event_name == 'pull_request'}}
     needs: [setup-environment]
     steps:
       - name: Checkout base branch


### PR DESCRIPTION
### What does this PR do?

Currently, the breaking changes workflow is failing for push events ([example](https://github.com/DataDog/opentelemetry-mapping-go/actions/runs/4678758871)).

This is due to the fact that `github.head_ref` is only available when the event that triggers a workflow run is either `pull_request` or `pull_request_target` (see [doc](https://docs.github.com/en/actions/learn-github-actions/contexts#:~:text=GitHub%20GraphQL%20API.-,github.head_ref,-string)).

- link to [push events](https://github.com/DataDog/opentelemetry-mapping-go/actions?query=event%3Apush) ❌
- link to [pull_request events](https://github.com/DataDog/opentelemetry-mapping-go/actions?query=event%3Apull_request) ✅

This PR modifies the breaking changes workflow to only run when the event_name is `pull_request`.

### Motivation

Failing tests ([example](https://github.com/DataDog/opentelemetry-mapping-go/actions/runs/4678758871)).

