### PR TITLE
[pkg/quantile] Increase ulpLimit to prevent flakes

### DIFF
--- a/pkg/quantile/summary/equal.go
+++ b/pkg/quantile/summary/equal.go
@@ -11,7 +11,7 @@ import (
 )
 
 const (
-	ulpLimit = 128
+	ulpLimit = 256
 )
 
 // ulpDistance is the absolute difference in units of least precision.


### PR DESCRIPTION
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Doubles ulpLimit to prevent `TestSummary/InsertN` from failing (see [sample failure](https://github.com/DataDog/opentelemetry-mapping-go/actions/runs/4499557031/jobs/7917577942)). 

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

`TestSummary/InsertN` is flaky in Go 1.20, but not on Go 1.19. This happens because of golang/go@90a67d052e6dc3f9d522820ca60cc9862a8016ba: we are not explicitly seeding the `math/rand` RNG, which means the sequence of random numbers is fixed in Go 1.19 and below, but non-deterministic after it. See also golang/go/issues/54880.

The test has probably been broken for a while, we just didn't notice because of the fixed inputs. We may want to revisit *why* the test is broken if we want to have a lower `ulpLimit`, but 256 still seems acceptable.