### PR TITLE
[pkg/otlp/attributes] Handle literal 'host' tag

### DIFF
--- a/.chloggen/mx-psi_literal-host.yaml
+++ b/.chloggen/mx-psi_literal-host.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component (e.g. pkg/quantile)
+component: pkg/otlp/attributes
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Handle literal 'host' attribute to avoid double tagging.
+
+# The PR related to this change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: This avoids double tagging when using `metrics::resource_attributes_as_tags` metrics, or in all cases for traces/logs.

--- a/pkg/otlp/attributes/source_test.go
+++ b/pkg/otlp/attributes/source_test.go
@@ -27,6 +27,7 @@ import (
 )
 
 const (
+	testLiteralHost            = "literal-host"
 	testHostID                 = "example-host-id"
 	testHostName               = "example-host-name"
 	testContainerID            = "example-container-id"
@@ -46,6 +47,20 @@ func TestSourceFromAttrs(t *testing.T) {
 		ok  bool
 		src source.Source
 	}{
+		{
+			name: "literal 'host' tag",
+			attrs: testutils.NewAttributeMap(map[string]string{
+				AttributeHost:                       testLiteralHost,
+				AttributeDatadogHostname:            testCustomName,
+				AttributeK8sNodeName:                testNodeName,
+				conventions.AttributeK8SClusterName: testClusterName,
+				conventions.AttributeContainerID:    testContainerID,
+				conventions.AttributeHostID:         testHostID,
+				conventions.AttributeHostName:       testHostName,
+			}),
+			ok:  true,
+			src: source.Source{Kind: source.HostnameKind, Identifier: testLiteralHost},
+		},
 		{
 			name: "custom hostname",
 			attrs: testutils.NewAttributeMap(map[string]string{
@@ -146,6 +161,14 @@ func TestSourceFromAttrs(t *testing.T) {
 		})
 
 	}
+}
+
+func TestLiteralHostNonString(t *testing.T) {
+	attrs := pcommon.NewMap()
+	attrs.PutInt(AttributeHost, 1000)
+	src, ok := SourceFromAttrs(attrs)
+	assert.True(t, ok)
+	assert.Equal(t, source.Source{Kind: source.HostnameKind, Identifier: "1000"}, src)
 }
 
 func TestGetClusterName(t *testing.T) {


### PR DESCRIPTION
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Handle literal 'host' attribute when determining the `host` tag value.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Not doing so causes two `host` tags/attributes to be present on all signal types under certain conditions.
