### PR TITLE
Add benchmark tests for runtime metric mappings

### DIFF
--- a/pkg/otlp/metrics/metrics_translator_benchmark_test.go
+++ b/pkg/otlp/metrics/metrics_translator_benchmark_test.go
@@ -28,6 +28,18 @@ import (
 	"github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes"
 )
 
+var inputTable = []struct {
+	input int
+}{
+	{input: 10},
+	{input: 100},
+	{input: 1000},
+	{input: 10000},
+	{input: 100000},
+	{input: 1000000},
+	{input: 10000000},
+}
+
 func newBenchmarkTranslator(b *testing.B, logger *zap.Logger, opts ...TranslatorOption) *Translator {
 	options := append([]TranslatorOption{
 		WithFallbackSourceProvider(testProvider("fallbackHostname")),
@@ -154,13 +166,71 @@ func createBenchmarkDeltaSumMetrics(n int, additionalAttributes map[string]strin
 	return md
 }
 
+func createBenchmarkRuntimeMetric(metricName string, metricType pmetric.MetricType, attributes []runtimeMetricAttribute, dataPoints int) pmetric.Metrics {
+	md := pmetric.NewMetrics()
+	met := md.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+	met.SetName(metricName)
+	var dpsInt pmetric.NumberDataPointSlice
+	var hpsCount pmetric.HistogramDataPointSlice
+	if metricType == pmetric.MetricTypeSum {
+		met.SetEmptySum()
+		met.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+		met.Sum().SetIsMonotonic(true)
+		dpsInt = met.Sum().DataPoints()
+	} else if metricType == pmetric.MetricTypeGauge {
+		met.SetEmptyGauge()
+		dpsInt = met.Gauge().DataPoints()
+	} else if metricType == pmetric.MetricTypeHistogram {
+		met.SetEmptyHistogram()
+		met.Histogram().SetAggregationTemporality(pmetric.AggregationTemporalityDelta)
+		hpsCount = met.Histogram().DataPoints()
+	}
+
+	if metricType != pmetric.MetricTypeHistogram {
+		dpsInt.EnsureCapacity(dataPoints)
+		for i := 0; i < dataPoints; i++ {
+			startTs := int(getProcessStartTime()) + 1
+			dpInt := dpsInt.AppendEmpty()
+			for _, attr := range attributes {
+				dpInt.Attributes().PutStr(attr.key, attr.values[0])
+			}
+			dpInt.SetStartTimestamp(seconds(startTs))
+			dpInt.SetTimestamp(seconds(startTs + 1 + i))
+			dpInt.SetIntValue(int64(10 * (1 + i)))
+		}
+		return md
+	}
+
+	hpsCount.EnsureCapacity(dataPoints)
+	for i := 0; i < dataPoints; i++ {
+		startTs := int(getProcessStartTime()) + 1
+		hpCount := hpsCount.AppendEmpty()
+		for _, attr := range attributes {
+			hpCount.Attributes().PutStr(attr.key, attr.values[0])
+		}
+		hpCount.SetStartTimestamp(seconds(startTs))
+		hpCount.SetTimestamp(seconds(startTs + 1 + i))
+		hpCount.ExplicitBounds().FromRaw([]float64{})
+		hpCount.BucketCounts().FromRaw([]uint64{100})
+		hpCount.SetCount(100)
+		hpCount.SetSum(0)
+		hpCount.SetMin(-100)
+		hpCount.SetMax(100)
+	}
+	return md
+}
+
 func benchmarkMapMetrics(metrics pmetric.Metrics, b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		ctx := context.Background()
 		tr := newBenchmarkTranslator(b, zap.NewNop())
 		consumer := &mockFullConsumer{}
-		err := tr.MapMetrics(ctx, metrics, consumer)
+
+		// Make deep copy of metrics to avoid mutation affecting benchmark tests
+		metricsCopy := pmetric.NewMetrics()
+		metrics.CopyTo(metricsCopy)
+		err := tr.MapMetrics(ctx, metricsCopy, consumer)
 		assert.NoError(b, err)
 	}
 }
@@ -381,74 +451,67 @@ func BenchmarkMapDeltaSumMetrics10(b *testing.B) {
 	benchmarkMapMetrics(metrics, b)
 }
 
-func BenchmarkMapDeltaSumMetrics100(b *testing.B) {
-	metrics := createBenchmarkDeltaSumMetrics(100, map[string]string{
-		"attribute_tag": "attribute_value",
-	})
-
-	benchmarkMapMetrics(metrics, b)
-}
-
-func BenchmarkMapDeltaSumMetrics1000(b *testing.B) {
-	metrics := createBenchmarkDeltaSumMetrics(1000, map[string]string{
-		"attribute_tag": "attribute_value",
-	})
-
-	benchmarkMapMetrics(metrics, b)
-}
-
-func BenchmarkMapDeltaSumMetrics10000(b *testing.B) {
-	metrics := createBenchmarkDeltaSumMetrics(10000, map[string]string{
-		"attribute_tag": "attribute_value",
-	})
-
-	benchmarkMapMetrics(metrics, b)
-}
-
-func BenchmarkMapDeltaSumMetrics100000(b *testing.B) {
-	metrics := createBenchmarkDeltaSumMetrics(100000, map[string]string{
-		"attribute_tag": "attribute_value",
-	})
-
-	benchmarkMapMetrics(metrics, b)
-}
-
-func BenchmarkMapDeltaSumMetrics1000000(b *testing.B) {
-	metrics := createBenchmarkDeltaSumMetrics(1000000, map[string]string{
-		"attribute_tag": "attribute_value",
-	})
-
-	benchmarkMapMetrics(metrics, b)
-}
-
-func BenchmarkMapDeltaSumMetrics10000000(b *testing.B) {
-	metrics := createBenchmarkDeltaSumMetrics(10000000, map[string]string{
-		"attribute_tag": "attribute_value",
-	})
-
-	benchmarkMapMetrics(metrics, b)
-}
-
-func BenchmarkMapRuntimeMetricsHasMapping(b *testing.B) {
-	ctx := context.Background()
-	tr := newBenchmarkTranslator(b, zap.NewNop())
-	consumer := &mockFullConsumer{}
-	exampleDims = newDims("process.runtime.go.goroutines")
-	for i := 0; i < b.N; i++ {
-		if err := tr.MapMetrics(ctx, createTestIntCumulativeMonotonicMetrics(false), consumer); err != nil {
-			b.Fatal(err)
-		}
+func BenchmarkMapSumRuntimeMetric(b *testing.B) {
+	for _, v := range inputTable {
+		b.Run(fmt.Sprintf("BenchmarkMapRuntimeMetricsHasMapping-%d", v.input), func(b *testing.B) {
+			benchmarkMapMetrics(createBenchmarkRuntimeMetric("process.runtime.go.goroutines", pmetric.MetricTypeSum, nil, v.input), b)
+		})
+		b.Run(fmt.Sprintf("BenchmarkMapRuntimeMetricsNoMapping-%d", v.input), func(b *testing.B) {
+			benchmarkMapMetrics(createBenchmarkRuntimeMetric("go.goroutines", pmetric.MetricTypeSum, nil, v.input), b)
+		})
 	}
 }
 
-func BenchmarkMapRuntimeMetricsHasNoMapping(b *testing.B) {
-	ctx := context.Background()
-	tr := newBenchmarkTranslator(b, zap.NewNop())
-	consumer := &mockFullConsumer{}
-	exampleDims = newDims("process.runtime.java.goroutines")
-	for i := 0; i < b.N; i++ {
-		if err := tr.MapMetrics(ctx, createTestIntCumulativeMonotonicMetrics(false), consumer); err != nil {
-			b.Fatal(err)
-		}
+func BenchmarkMapGaugeRuntimeMetricWithAttributesHasMapping(b *testing.B) {
+	attr := []runtimeMetricAttribute{{
+		key:    "generation",
+		values: []string{"gen1"},
+	}}
+
+	for _, v := range inputTable {
+		b.Run(fmt.Sprintf("BenchmarkMapGaugeRuntimeMetricWithAttributesHasMapping-%d", v.input), func(b *testing.B) {
+			benchmarkMapMetrics(createBenchmarkRuntimeMetric("process.runtime.dotnet.gc.heap.size", pmetric.MetricTypeGauge, attr, v.input), b)
+		})
+		b.Run(fmt.Sprintf("BenchmarkMapGaugeRuntimeMetricWithAttributesNoMapping-%d", v.input), func(b *testing.B) {
+			benchmarkMapMetrics(createBenchmarkRuntimeMetric("dotnet.gc.heap.size", pmetric.MetricTypeGauge, attr, v.input), b)
+		})
+	}
+}
+
+func BenchmarkMapGaugeRuntimeMetricWith10AttributesHasMapping(b *testing.B) {
+	var attr []runtimeMetricAttribute
+	for i := 1; i <= 10; i++ {
+		attr = append(attr, runtimeMetricAttribute{
+			key:    "generation",
+			values: []string{fmt.Sprintf("gen%d", i)},
+		})
+	}
+
+	for _, v := range inputTable {
+		b.Run(fmt.Sprintf("BenchmarkMapGaugeRuntimeMetricWith10AttributesHasMapping-%d", v.input), func(b *testing.B) {
+			benchmarkMapMetrics(createBenchmarkRuntimeMetric("process.runtime.dotnet.gc.heap.size", pmetric.MetricTypeGauge, attr, v.input), b)
+		})
+		b.Run(fmt.Sprintf("BenchmarkMapGaugeRuntimeMetricWith10AttributesNoMapping-%d", v.input), func(b *testing.B) {
+			benchmarkMapMetrics(createBenchmarkRuntimeMetric("dotnet.gc.heap.size", pmetric.MetricTypeGauge, attr, v.input), b)
+		})
+	}
+}
+
+func BenchmarkMapGaugeRuntimeMetricWith100AttributesHasMapping(b *testing.B) {
+	var attr []runtimeMetricAttribute
+	for i := 1; i <= 100; i++ {
+		attr = append(attr, runtimeMetricAttribute{
+			key:    "generation",
+			values: []string{fmt.Sprintf("gen%d", i)},
+		})
+	}
+
+	for _, v := range inputTable {
+		b.Run(fmt.Sprintf("BenchmarkMapGaugeRuntimeMetricWith100AttributesHasMapping-%d", v.input), func(b *testing.B) {
+			benchmarkMapMetrics(createBenchmarkRuntimeMetric("process.runtime.dotnet.gc.heap.size", pmetric.MetricTypeGauge, attr, v.input), b)
+		})
+		b.Run(fmt.Sprintf("BenchmarkMapGaugeRuntimeMetricWith100AttributesNoMapping-%d", v.input), func(b *testing.B) {
+			benchmarkMapMetrics(createBenchmarkRuntimeMetric("dotnet.gc.heap.size", pmetric.MetricTypeGauge, attr, v.input), b)
+		})
 	}
 }

--- a/pkg/otlp/metrics/metrics_translator_benchmark_test.go
+++ b/pkg/otlp/metrics/metrics_translator_benchmark_test.go
@@ -28,6 +28,11 @@ import (
 	"github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes"
 )
 
+const (
+	runtimeMetricWithMapping = "process.runtime.dotnet.gc.heap.size"
+	runtimeMetricNoMapping   = "dotnet.gc.heap.size"
+)
+
 var inputTable = []struct {
 	input int
 }{
@@ -502,10 +507,10 @@ func BenchmarkMapDeltaSumMetrics10000000(b *testing.B) {
 func BenchmarkMapSumRuntimeMetric(b *testing.B) {
 	for _, v := range inputTable {
 		b.Run(fmt.Sprintf("BenchmarkMapRuntimeMetricsHasMapping-%d", v.input), func(b *testing.B) {
-			benchmarkMapMetrics(createBenchmarkRuntimeMetric("process.runtime.go.goroutines", pmetric.MetricTypeSum, nil, v.input), b)
+			benchmarkMapMetrics(createBenchmarkRuntimeMetric(runtimeMetricWithMapping, pmetric.MetricTypeSum, nil, v.input), b)
 		})
 		b.Run(fmt.Sprintf("BenchmarkMapRuntimeMetricsNoMapping-%d", v.input), func(b *testing.B) {
-			benchmarkMapMetrics(createBenchmarkRuntimeMetric("go.goroutines", pmetric.MetricTypeSum, nil, v.input), b)
+			benchmarkMapMetrics(createBenchmarkRuntimeMetric(runtimeMetricNoMapping, pmetric.MetricTypeSum, nil, v.input), b)
 		})
 	}
 }
@@ -518,10 +523,10 @@ func BenchmarkMapGaugeRuntimeMetricWithAttributesHasMapping(b *testing.B) {
 
 	for _, v := range inputTable {
 		b.Run(fmt.Sprintf("BenchmarkMapGaugeRuntimeMetricWithAttributesHasMapping-%d", v.input), func(b *testing.B) {
-			benchmarkMapMetrics(createBenchmarkRuntimeMetric("process.runtime.dotnet.gc.heap.size", pmetric.MetricTypeGauge, attr, v.input), b)
+			benchmarkMapMetrics(createBenchmarkRuntimeMetric(runtimeMetricWithMapping, pmetric.MetricTypeGauge, attr, v.input), b)
 		})
 		b.Run(fmt.Sprintf("BenchmarkMapGaugeRuntimeMetricWithAttributesNoMapping-%d", v.input), func(b *testing.B) {
-			benchmarkMapMetrics(createBenchmarkRuntimeMetric("dotnet.gc.heap.size", pmetric.MetricTypeGauge, attr, v.input), b)
+			benchmarkMapMetrics(createBenchmarkRuntimeMetric(runtimeMetricNoMapping, pmetric.MetricTypeGauge, attr, v.input), b)
 		})
 	}
 }
@@ -537,10 +542,10 @@ func BenchmarkMapGaugeRuntimeMetricWith10AttributesHasMapping(b *testing.B) {
 
 	for _, v := range inputTable {
 		b.Run(fmt.Sprintf("BenchmarkMapGaugeRuntimeMetricWith10AttributesHasMapping-%d", v.input), func(b *testing.B) {
-			benchmarkMapMetrics(createBenchmarkRuntimeMetric("process.runtime.dotnet.gc.heap.size", pmetric.MetricTypeGauge, attr, v.input), b)
+			benchmarkMapMetrics(createBenchmarkRuntimeMetric(runtimeMetricWithMapping, pmetric.MetricTypeGauge, attr, v.input), b)
 		})
 		b.Run(fmt.Sprintf("BenchmarkMapGaugeRuntimeMetricWith10AttributesNoMapping-%d", v.input), func(b *testing.B) {
-			benchmarkMapMetrics(createBenchmarkRuntimeMetric("dotnet.gc.heap.size", pmetric.MetricTypeGauge, attr, v.input), b)
+			benchmarkMapMetrics(createBenchmarkRuntimeMetric(runtimeMetricNoMapping, pmetric.MetricTypeGauge, attr, v.input), b)
 		})
 	}
 }
@@ -556,10 +561,10 @@ func BenchmarkMapGaugeRuntimeMetricWith100AttributesHasMapping(b *testing.B) {
 
 	for _, v := range inputTable {
 		b.Run(fmt.Sprintf("BenchmarkMapGaugeRuntimeMetricWith100AttributesHasMapping-%d", v.input), func(b *testing.B) {
-			benchmarkMapMetrics(createBenchmarkRuntimeMetric("process.runtime.dotnet.gc.heap.size", pmetric.MetricTypeGauge, attr, v.input), b)
+			benchmarkMapMetrics(createBenchmarkRuntimeMetric(runtimeMetricWithMapping, pmetric.MetricTypeGauge, attr, v.input), b)
 		})
 		b.Run(fmt.Sprintf("BenchmarkMapGaugeRuntimeMetricWith100AttributesNoMapping-%d", v.input), func(b *testing.B) {
-			benchmarkMapMetrics(createBenchmarkRuntimeMetric("dotnet.gc.heap.size", pmetric.MetricTypeGauge, attr, v.input), b)
+			benchmarkMapMetrics(createBenchmarkRuntimeMetric(runtimeMetricNoMapping, pmetric.MetricTypeGauge, attr, v.input), b)
 		})
 	}
 }

--- a/pkg/otlp/metrics/metrics_translator_benchmark_test.go
+++ b/pkg/otlp/metrics/metrics_translator_benchmark_test.go
@@ -451,6 +451,54 @@ func BenchmarkMapDeltaSumMetrics10(b *testing.B) {
 	benchmarkMapMetrics(metrics, b)
 }
 
+func BenchmarkMapDeltaSumMetrics100(b *testing.B) {
+	metrics := createBenchmarkDeltaSumMetrics(100, map[string]string{
+		"attribute_tag": "attribute_value",
+	})
+
+	benchmarkMapMetrics(metrics, b)
+}
+
+func BenchmarkMapDeltaSumMetrics1000(b *testing.B) {
+	metrics := createBenchmarkDeltaSumMetrics(1000, map[string]string{
+		"attribute_tag": "attribute_value",
+	})
+
+	benchmarkMapMetrics(metrics, b)
+}
+
+func BenchmarkMapDeltaSumMetrics10000(b *testing.B) {
+	metrics := createBenchmarkDeltaSumMetrics(10000, map[string]string{
+		"attribute_tag": "attribute_value",
+	})
+
+	benchmarkMapMetrics(metrics, b)
+}
+
+func BenchmarkMapDeltaSumMetrics100000(b *testing.B) {
+	metrics := createBenchmarkDeltaSumMetrics(100000, map[string]string{
+		"attribute_tag": "attribute_value",
+	})
+
+	benchmarkMapMetrics(metrics, b)
+}
+
+func BenchmarkMapDeltaSumMetrics1000000(b *testing.B) {
+	metrics := createBenchmarkDeltaSumMetrics(1000000, map[string]string{
+		"attribute_tag": "attribute_value",
+	})
+
+	benchmarkMapMetrics(metrics, b)
+}
+
+func BenchmarkMapDeltaSumMetrics10000000(b *testing.B) {
+	metrics := createBenchmarkDeltaSumMetrics(10000000, map[string]string{
+		"attribute_tag": "attribute_value",
+	})
+
+	benchmarkMapMetrics(metrics, b)
+}
+
 func BenchmarkMapSumRuntimeMetric(b *testing.B) {
 	for _, v := range inputTable {
 		b.Run(fmt.Sprintf("BenchmarkMapRuntimeMetricsHasMapping-%d", v.input), func(b *testing.B) {

--- a/pkg/otlp/metrics/metrics_translator_benchmark_test.go
+++ b/pkg/otlp/metrics/metrics_translator_benchmark_test.go
@@ -428,3 +428,27 @@ func BenchmarkMapDeltaSumMetrics10000000(b *testing.B) {
 
 	benchmarkMapMetrics(metrics, b)
 }
+
+func BenchmarkMapRuntimeMetricsHasMapping(b *testing.B) {
+	ctx := context.Background()
+	tr := newBenchmarkTranslator(b, zap.NewNop())
+	consumer := &mockFullConsumer{}
+	exampleDims = newDims("process.runtime.go.goroutines")
+	for i := 0; i < b.N; i++ {
+		if err := tr.MapMetrics(ctx, createTestIntCumulativeMonotonicMetrics(false), consumer); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+func BenchmarkMapRuntimeMetricsHasNoMapping(b *testing.B) {
+	ctx := context.Background()
+	tr := newBenchmarkTranslator(b, zap.NewNop())
+	consumer := &mockFullConsumer{}
+	exampleDims = newDims("process.runtime.java.goroutines")
+	for i := 0; i < b.N; i++ {
+		if err := tr.MapMetrics(ctx, createTestIntCumulativeMonotonicMetrics(false), consumer); err != nil {
+			b.Fatal(err)
+		}
+	}
+}

--- a/pkg/otlp/metrics/metrics_translator_test.go
+++ b/pkg/otlp/metrics/metrics_translator_test.go
@@ -16,7 +16,6 @@ package metrics
 
 import (
 	"context"
-	"fmt"
 	"math"
 	"testing"
 	"time"
@@ -471,7 +470,6 @@ func TestMapHistogramRuntimeMetricHasMapping(t *testing.T) {
 	ctx := context.Background()
 	tr := newTranslator(t, zap.NewNop())
 	consumer := &mockFullConsumer{}
-	fmt.Println(consumer.metrics)
 
 	if err := tr.MapMetrics(ctx, createTestHistogramMetric("process.runtime.jvm.gc.duration"), consumer); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Add benchmark tests for the following cases, both with and without mappings:
- Mapping sum runtime metric without attributes
- Mapping gauge runtime metric with 1 attribute
- Mapping gauge runtime metric with 10 attributes
- Mapping gauge runtime metric with 100 attributes

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

### Results

For a runtime metric without attributes, it seems to take double the amount of time with the runtime metric mapping. As you add more attributes to the runtime metrics, the performance of the runtime metric mapping becomes closer to the performance without the runtime metric mapping.

```
BenchmarkMapSumRuntimeMetric/BenchmarkMapRuntimeMetricsHasMapping-10-10         	   57350	     20915 ns/op
BenchmarkMapSumRuntimeMetric/BenchmarkMapRuntimeMetricsNoMapping-10-10          	  104792	     11669 ns/op

BenchmarkMapSumRuntimeMetric/BenchmarkMapRuntimeMetricsHasMapping-100-10        	    7374	    161524 ns/op
BenchmarkMapSumRuntimeMetric/BenchmarkMapRuntimeMetricsNoMapping-100-10         	   14056	     85740 ns/op

BenchmarkMapSumRuntimeMetric/BenchmarkMapRuntimeMetricsHasMapping-1000-10       	     726	   1656680 ns/op
BenchmarkMapSumRuntimeMetric/BenchmarkMapRuntimeMetricsNoMapping-1000-10        	    1479	    804701 ns/op

BenchmarkMapSumRuntimeMetric/BenchmarkMapRuntimeMetricsHasMapping-10000-10      	      72	  15482890 ns/op
BenchmarkMapSumRuntimeMetric/BenchmarkMapRuntimeMetricsNoMapping-10000-10       	     146	   8141441 ns/op

BenchmarkMapSumRuntimeMetric/BenchmarkMapRuntimeMetricsHasMapping-100000-10     	       8	 136027427 ns/op
BenchmarkMapSumRuntimeMetric/BenchmarkMapRuntimeMetricsNoMapping-100000-10      	      16	  70941406 ns/op

BenchmarkMapSumRuntimeMetric/BenchmarkMapRuntimeMetricsHasMapping-1000000-10    	       1	1335716042 ns/op
BenchmarkMapSumRuntimeMetric/BenchmarkMapRuntimeMetricsNoMapping-1000000-10     	       2	 719938542 ns/op

BenchmarkMapSumRuntimeMetric/BenchmarkMapRuntimeMetricsHasMapping-10000000-10   	       1	14546480541 ns/op
BenchmarkMapSumRuntimeMetric/BenchmarkMapRuntimeMetricsNoMapping-10000000-10    	       1	7446288500 ns/op

BenchmarkMapGaugeRuntimeMetricWithAttributesHasMapping/BenchmarkMapGaugeRuntimeMetricWithAttributesHasMapping-10-10         	   87964	     12924 ns/op
BenchmarkMapGaugeRuntimeMetricWithAttributesHasMapping/BenchmarkMapGaugeRuntimeMetricWithAttributesNoMapping-10-10          	  169436	      7423 ns/op

BenchmarkMapGaugeRuntimeMetricWithAttributesHasMapping/BenchmarkMapGaugeRuntimeMetricWithAttributesHasMapping-100-10        	   13754	     92834 ns/op
BenchmarkMapGaugeRuntimeMetricWithAttributesHasMapping/BenchmarkMapGaugeRuntimeMetricWithAttributesNoMapping-100-10         	   29301	     40753 ns/op

BenchmarkMapGaugeRuntimeMetricWithAttributesHasMapping/BenchmarkMapGaugeRuntimeMetricWithAttributesHasMapping-1000-10       	    1389	    878318 ns/op
BenchmarkMapGaugeRuntimeMetricWithAttributesHasMapping/BenchmarkMapGaugeRuntimeMetricWithAttributesNoMapping-1000-10        	    3328	    357321 ns/op

BenchmarkMapGaugeRuntimeMetricWithAttributesHasMapping/BenchmarkMapGaugeRuntimeMetricWithAttributesHasMapping-10000-10      	     138	   8730911 ns/op
BenchmarkMapGaugeRuntimeMetricWithAttributesHasMapping/BenchmarkMapGaugeRuntimeMetricWithAttributesNoMapping-10000-10       	     309	   3892524 ns/op

BenchmarkMapGaugeRuntimeMetricWithAttributesHasMapping/BenchmarkMapGaugeRuntimeMetricWithAttributesHasMapping-100000-10     	      13	  80329654 ns/op
BenchmarkMapGaugeRuntimeMetricWithAttributesHasMapping/BenchmarkMapGaugeRuntimeMetricWithAttributesNoMapping-100000-10      	      33	  35673785 ns/op

BenchmarkMapGaugeRuntimeMetricWithAttributesHasMapping/BenchmarkMapGaugeRuntimeMetricWithAttributesHasMapping-1000000-10    	       2	 788845166 ns/op
BenchmarkMapGaugeRuntimeMetricWithAttributesHasMapping/BenchmarkMapGaugeRuntimeMetricWithAttributesNoMapping-1000000-10     	       3	 336377125 ns/op

BenchmarkMapGaugeRuntimeMetricWithAttributesHasMapping/BenchmarkMapGaugeRuntimeMetricWithAttributesHasMapping-10000000-10   	       1	9449124458 ns/op
BenchmarkMapGaugeRuntimeMetricWithAttributesHasMapping/BenchmarkMapGaugeRuntimeMetricWithAttributesNoMapping-10000000-10    	       1	3818822542 ns/op

BenchmarkMapGaugeRuntimeMetricWith10AttributesHasMapping/BenchmarkMapGaugeRuntimeMetricWith10AttributesHasMapping-10-10     	  142412	      8565 ns/op
BenchmarkMapGaugeRuntimeMetricWith10AttributesHasMapping/BenchmarkMapGaugeRuntimeMetricWith10AttributesNoMapping-10-10      	  150063	      7836 ns/op

BenchmarkMapGaugeRuntimeMetricWith10AttributesHasMapping/BenchmarkMapGaugeRuntimeMetricWith10AttributesHasMapping-100-10    	   25635	     46548 ns/op
BenchmarkMapGaugeRuntimeMetricWith10AttributesHasMapping/BenchmarkMapGaugeRuntimeMetricWith10AttributesNoMapping-100-10     	   28135	     42613 ns/op

BenchmarkMapGaugeRuntimeMetricWith10AttributesHasMapping/BenchmarkMapGaugeRuntimeMetricWith10AttributesHasMapping-1000-10   	    2949	    411538 ns/op
BenchmarkMapGaugeRuntimeMetricWith10AttributesHasMapping/BenchmarkMapGaugeRuntimeMetricWith10AttributesNoMapping-1000-10    	    3290	    374780 ns/op

BenchmarkMapGaugeRuntimeMetricWith10AttributesHasMapping/BenchmarkMapGaugeRuntimeMetricWith10AttributesHasMapping-10000-10  	     273	   4322787 ns/op
BenchmarkMapGaugeRuntimeMetricWith10AttributesHasMapping/BenchmarkMapGaugeRuntimeMetricWith10AttributesNoMapping-10000-10   	     304	   3909964 ns/op

BenchmarkMapGaugeRuntimeMetricWith10AttributesHasMapping/BenchmarkMapGaugeRuntimeMetricWith10AttributesHasMapping-100000-10 	      27	  40675327 ns/op
BenchmarkMapGaugeRuntimeMetricWith10AttributesHasMapping/BenchmarkMapGaugeRuntimeMetricWith10AttributesNoMapping-100000-10  	      33	  34764496 ns/op

BenchmarkMapGaugeRuntimeMetricWith10AttributesHasMapping/BenchmarkMapGaugeRuntimeMetricWith10AttributesHasMapping-1000000-10         	       3	 425759639 ns/op
BenchmarkMapGaugeRuntimeMetricWith10AttributesHasMapping/BenchmarkMapGaugeRuntimeMetricWith10AttributesNoMapping-1000000-10          	       3	 341386528 ns/op

BenchmarkMapGaugeRuntimeMetricWith10AttributesHasMapping/BenchmarkMapGaugeRuntimeMetricWith10AttributesHasMapping-10000000-10        	       1	4507138833 ns/op
BenchmarkMapGaugeRuntimeMetricWith10AttributesHasMapping/BenchmarkMapGaugeRuntimeMetricWith10AttributesNoMapping-10000000-10         	       1	3631452834 ns/op

BenchmarkMapGaugeRuntimeMetricWith100AttributesHasMapping/BenchmarkMapGaugeRuntimeMetricWith100AttributesHasMapping-10-10            	  157543	      7897 ns/op
BenchmarkMapGaugeRuntimeMetricWith100AttributesHasMapping/BenchmarkMapGaugeRuntimeMetricWith100AttributesNoMapping-10-10             	  171310	      7111 ns/op

BenchmarkMapGaugeRuntimeMetricWith100AttributesHasMapping/BenchmarkMapGaugeRuntimeMetricWith100AttributesHasMapping-100-10           	   25994	     46743 ns/op
BenchmarkMapGaugeRuntimeMetricWith100AttributesHasMapping/BenchmarkMapGaugeRuntimeMetricWith100AttributesNoMapping-100-10            	   28473	     41966 ns/op

BenchmarkMapGaugeRuntimeMetricWith100AttributesHasMapping/BenchmarkMapGaugeRuntimeMetricWith100AttributesHasMapping-1000-10          	    2884	    414421 ns/op
BenchmarkMapGaugeRuntimeMetricWith100AttributesHasMapping/BenchmarkMapGaugeRuntimeMetricWith100AttributesNoMapping-1000-10           	    3260	    367849 ns/op

BenchmarkMapGaugeRuntimeMetricWith100AttributesHasMapping/BenchmarkMapGaugeRuntimeMetricWith100AttributesHasMapping-10000-10         	     262	   4469043 ns/op
BenchmarkMapGaugeRuntimeMetricWith100AttributesHasMapping/BenchmarkMapGaugeRuntimeMetricWith100AttributesNoMapping-10000-10          	     304	   4000773 ns/op

BenchmarkMapGaugeRuntimeMetricWith100AttributesHasMapping/BenchmarkMapGaugeRuntimeMetricWith100AttributesHasMapping-100000-10        	      25	  46025868 ns/op
BenchmarkMapGaugeRuntimeMetricWith100AttributesHasMapping/BenchmarkMapGaugeRuntimeMetricWith100AttributesNoMapping-100000-10         	      28	  37843606 ns/op

BenchmarkMapGaugeRuntimeMetricWith100AttributesHasMapping/BenchmarkMapGaugeRuntimeMetricWith100AttributesHasMapping-1000000-10       	       2	 523577938 ns/op
BenchmarkMapGaugeRuntimeMetricWith100AttributesHasMapping/BenchmarkMapGaugeRuntimeMetricWith100AttributesNoMapping-1000000-10        	       3	 370270903 ns/op

BenchmarkMapGaugeRuntimeMetricWith100AttributesHasMapping/BenchmarkMapGaugeRuntimeMetricWith100AttributesHasMapping-10000000-10      	       1	6013783583 ns/op
BenchmarkMapGaugeRuntimeMetricWith100AttributesHasMapping/BenchmarkMapGaugeRuntimeMetricWith100AttributesNoMapping-10000000-10       	       1	4259572625 ns/op
```
