### PR TITLE
pkg/otlp/attributes: add remapping for container.runtime

### DIFF
--- a/pkg/otlp/attributes/attributes.go
+++ b/pkg/otlp/attributes/attributes.go
@@ -36,6 +36,7 @@ var (
 		conventions.AttributeContainerName:      "container_name",
 		conventions.AttributeContainerImageName: "image_name",
 		conventions.AttributeContainerImageTag:  "image_tag",
+		conventions.AttributeContainerRuntime:   "runtime",
 
 		// Cloud conventions
 		// https://www.datadoghq.com/blog/tagging-best-practices/
@@ -71,6 +72,7 @@ var (
 		conventions.AttributeContainerName,
 		conventions.AttributeContainerImageName,
 		conventions.AttributeContainerImageTag,
+		conventions.AttributeContainerRuntime,
 		conventions.AttributeK8SContainerName,
 		conventions.AttributeK8SClusterName,
 		conventions.AttributeK8SDeploymentName,

--- a/pkg/otlp/attributes/attributes_test.go
+++ b/pkg/otlp/attributes/attributes_test.go
@@ -34,6 +34,7 @@ func TestTagsFromAttributes(t *testing.T) {
 		conventions.AttributeOSType:                "linux",
 		conventions.AttributeK8SDaemonSetName:      "daemon_set_name",
 		conventions.AttributeAWSECSClusterARN:      "cluster_arn",
+		conventions.AttributeContainerRuntime:      "cro",
 		"tags.datadoghq.com/service":               "service_name",
 	}
 	attrs := pcommon.NewMap()
@@ -45,6 +46,7 @@ func TestTagsFromAttributes(t *testing.T) {
 		fmt.Sprintf("%s:%s", "kube_daemon_set", "daemon_set_name"),
 		fmt.Sprintf("%s:%s", "ecs_cluster_name", "cluster_arn"),
 		fmt.Sprintf("%s:%s", "service", "service_name"),
+		fmt.Sprintf("%s:%s", "runtime", "cro"),
 	}, TagsFromAttributes(attrs))
 }
 
@@ -58,6 +60,7 @@ func TestContainerTagFromAttributes(t *testing.T) {
 	attributeMap := map[string]string{
 		conventions.AttributeContainerName:         "sample_app",
 		conventions.AttributeContainerImageTag:     "sample_app_image_tag",
+		conventions.AttributeContainerRuntime:      "cro",
 		conventions.AttributeK8SContainerName:      "kube_sample_app",
 		conventions.AttributeK8SReplicaSetName:     "sample_replica_set",
 		conventions.AttributeK8SDaemonSetName:      "sample_daemonset_name",
@@ -76,6 +79,7 @@ func TestContainerTagFromAttributes(t *testing.T) {
 	assert.Equal(t, map[string]string{
 		"container_name":      "sample_app",
 		"image_tag":           "sample_app_image_tag",
+		"runtime":             "cro",
 		"kube_container_name": "kube_sample_app",
 		"kube_replica_set":    "sample_replica_set",
 		"kube_daemon_set":     "sample_daemonset_name",


### PR DESCRIPTION
### What does this PR do?

Add remapping of semantic convention `container.runtime` to Datadog's counterpart `runtime`.

### Motivation

Needed for container metrics dashboard to function correctly. It is one of the global filters.
