### PR TITLE
pkg/otlp/metrics: add remapping code

### DIFF
--- a/.chloggen/gbbr_remap-metrics.yaml
+++ b/.chloggen/gbbr_remap-metrics.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component (e.g. pkg/quantile)
+component: pkg/otlp/metrics
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: A new Translator configuration option (WithRemapping) can be used to extract Datadog system and container metrics.
+
+# The PR related to this change
+issues: [102]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/pkg/otlp/metrics/config.go
+++ b/pkg/otlp/metrics/config.go
@@ -51,6 +51,9 @@ type TranslatorOption func(*translatorConfig) error
 // WithRemapping specifies that certain OTEL metrics (such as container.* and system.*) need to be
 // remapped to their Datadog counterparts because they will not be available otherwise. This happens
 // in situations when the translator is running as part of a Collector without the Datadog Agent.
+//
+// Do note that in some scenarios this process renames certain metrics (such as for example prefixing
+// system.* and process.* metrics with the otel.* namespace).
 func WithRemapping() TranslatorOption {
 	return func(t *translatorConfig) error {
 		t.withRemapping = true

--- a/pkg/otlp/metrics/config.go
+++ b/pkg/otlp/metrics/config.go
@@ -33,6 +33,11 @@ type translatorConfig struct {
 	InstrumentationLibraryMetadataAsTags bool
 	InstrumentationScopeMetadataAsTags   bool
 
+	// withRemapping reports whether certain metrics that are only available when using
+	// the Datadog Agent should be obtained by remapping from OTEL counterparts (e.g.
+	// container.* and system.* metrics).
+	withRemapping bool
+
 	// cache configuration
 	sweepInterval int64
 	deltaTTL      int64
@@ -42,6 +47,16 @@ type translatorConfig struct {
 
 // TranslatorOption is a translator creation option.
 type TranslatorOption func(*translatorConfig) error
+
+// WithRemapping specifies that certain OTEL metrics (such as container.* and system.*) need to be
+// remapped to their Datadog counterparts because they will not be available otherwise. This happens
+// in situations when the translator is running as part of a Collector without the Datadog Agent.
+func WithRemapping() TranslatorOption {
+	return func(t *translatorConfig) error {
+		t.withRemapping = true
+		return nil
+	}
+}
 
 // WithDeltaTTL sets the delta TTL for cumulative metrics datapoints.
 // By default, 3600 seconds are used.

--- a/pkg/otlp/metrics/metrics_remapping.go
+++ b/pkg/otlp/metrics/metrics_remapping.go
@@ -48,15 +48,11 @@ func remapSystemMetrics(all pmetric.MetricSlice, m pmetric.Metric) {
 	case "system.cpu.load_average.15m":
 		copyMetric(all, m, "system.load.15", 1)
 	case "system.cpu.utilization":
-		for name, state := range map[string]string{
-			"system.cpu.idle":   "idle",
-			"system.cpu.user":   "user",
-			"system.cpu.system": "system",
-			"system.cpu.iowait": "wait",
-			"system.cpu.stolen": "steal",
-		} {
-			copyMetric(all, m, name, divPercentage, kv{"state", state})
-		}
+		copyMetric(all, m, "system.cpu.idle", divPercentage, kv{"state", "idle"})
+		copyMetric(all, m, "system.cpu.user", divPercentage, kv{"state", "user"})
+		copyMetric(all, m, "system.cpu.system", divPercentage, kv{"state", "system"})
+		copyMetric(all, m, "system.cpu.iowait", divPercentage, kv{"state", "wait"})
+		copyMetric(all, m, "system.cpu.stolen", divPercentage, kv{"state", "steal"})
 	case "system.memory.usage":
 		copyMetric(all, m, "system.mem.total", divMebibytes)
 		copyMetric(all, m, "system.mem.usable", divMebibytes,
@@ -158,9 +154,14 @@ func copyMetric(dest pmetric.MetricSlice, m pmetric.Metric, newname string, div 
 		}
 		switch dp.ValueType() {
 		case pmetric.NumberDataPointValueTypeInt:
-			dp.SetIntValue(dp.IntValue() / int64(div))
+			if div >= 1 {
+				// avoid division by zero
+				dp.SetIntValue(dp.IntValue() / int64(div))
+			}
 		case pmetric.NumberDataPointValueTypeDouble:
-			dp.SetDoubleValue(dp.DoubleValue() / div)
+			if div != 0 {
+				dp.SetDoubleValue(dp.DoubleValue() / div)
+			}
 		}
 		return false
 	})

--- a/pkg/otlp/metrics/metrics_remapping.go
+++ b/pkg/otlp/metrics/metrics_remapping.go
@@ -1,0 +1,193 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"strings"
+
+	"go.opentelemetry.io/collector/pdata/pmetric"
+)
+
+const (
+	// divMebibytes specifies the number of bytes in a mebibyte.
+	divMebibytes = 1024 * 1024
+	// divPercentage specifies the division necessary for converting fractions to percentages.
+	divPercentage = 0.01
+)
+
+// remapMetrics extracts any Datadog specific metrics from m and appends them to all.
+func remapMetrics(all pmetric.MetricSlice, m pmetric.Metric) {
+	remapSystemMetrics(all, m)
+	remapContainerMetrics(all, m)
+}
+
+// remapSystemMetrics extracts system metrics from m and appends them to all.
+func remapSystemMetrics(all pmetric.MetricSlice, m pmetric.Metric) {
+	name := m.Name()
+	if !strings.HasPrefix(name, "process.") && !strings.HasPrefix(name, "system.") {
+		// not a system metric
+		return
+	}
+	switch name {
+	case "system.cpu.load_average.1m":
+		copyMetric(all, m, "system.load.1", 1)
+	case "system.cpu.load_average.5m":
+		copyMetric(all, m, "system.load.5", 1)
+	case "system.cpu.load_average.15m":
+		copyMetric(all, m, "system.load.15", 1)
+	case "system.cpu.utilization":
+		for name, state := range map[string]string{
+			"system.cpu.idle":   "idle",
+			"system.cpu.user":   "user",
+			"system.cpu.system": "system",
+			"system.cpu.iowait": "wait",
+			"system.cpu.stolen": "steal",
+		} {
+			copyMetric(all, m, name, divPercentage, kv{"state", state})
+		}
+	case "system.memory.usage":
+		copyMetric(all, m, "system.mem.total", divMebibytes)
+		copyMetric(all, m, "system.mem.usable", divMebibytes,
+			kv{"state", "free"},
+			kv{"state", "cached"},
+			kv{"state", "buffered"},
+		)
+	case "system.network.io":
+		copyMetric(all, m, "system.net.bytes_rcvd", 1, kv{"direction", "receive"})
+		copyMetric(all, m, "system.net.bytes_sent", 1, kv{"direction", "transmit"})
+	case "system.paging.usage":
+		copyMetric(all, m, "system.swap.free", divMebibytes, kv{"state", "free"})
+		copyMetric(all, m, "system.swap.used", divMebibytes, kv{"state", "used"})
+	case "system.filesystem.utilization":
+		copyMetric(all, m, "system.disk.in_use", 1)
+	}
+	// process.* and system.* metrics need to be prepended with the otel.* namespace
+	m.SetName("otel." + m.Name())
+}
+
+// remapContainerMetrics extracts system metrics from m and appends them to all.
+func remapContainerMetrics(all pmetric.MetricSlice, m pmetric.Metric) {
+	name := m.Name()
+	if !strings.HasPrefix(name, "container.") {
+		// not a container metric
+		return
+	}
+	switch name {
+	case "container.cpu.usage.total":
+		if addm, ok := copyMetric(all, m, "container.cpu.usage", 1); ok {
+			addm.SetUnit("nanocore")
+		}
+	case "container.cpu.usage.usermode":
+		if addm, ok := copyMetric(all, m, "container.cpu.user", 1); ok {
+			addm.SetUnit("nanocore")
+		}
+	case "container.cpu.usage.system":
+		if addm, ok := copyMetric(all, m, "container.cpu.system", 1); ok {
+			addm.SetUnit("nanocore")
+		}
+	case "container.cpu.throttling_data.throttled_time":
+		copyMetric(all, m, "container.cpu.throttled", 1)
+	case "container.cpu.throttling_data.throttled_periods":
+		copyMetric(all, m, "container.cpu.throttled.periods", 1)
+	case "container.memory.usage.total":
+		copyMetric(all, m, "container.memory.usage", 1)
+	case "container.memory.active_anon":
+		copyMetric(all, m, "container.memory.kernel", 1)
+	case "container.memory.hierarchical_memory_limit":
+		copyMetric(all, m, "container.memory.limit", 1)
+	case "container.memory.usage.limit":
+		copyMetric(all, m, "container.memory.soft_limit", 1)
+	case "container.memory.total_cache":
+		copyMetric(all, m, "container.memory.cache", 1)
+	case "container.memory.total_swap":
+		copyMetric(all, m, "container.memory.swap", 1)
+	case "container.blockio.io_service_bytes_recursive":
+		copyMetric(all, m, "container.io.write", 1, kv{"operation", "write"})
+		copyMetric(all, m, "container.io.read", 1, kv{"operation", "read"})
+	case "container.blockio.io_serviced_recursive":
+		copyMetric(all, m, "container.io.write.operations", 1, kv{"operation", "write"})
+		copyMetric(all, m, "container.io.read.operations", 1, kv{"operation", "read"})
+	case "container.network.io.usage.tx_bytes":
+		copyMetric(all, m, "container.net.sent", 1)
+	case "container.network.io.usage.tx_packets":
+		copyMetric(all, m, "container.net.sent.packets", 1)
+	case "container.network.io.usage.rx_bytes":
+		copyMetric(all, m, "container.net.rcvd", 1)
+	case "container.network.io.usage.rx_packets":
+		copyMetric(all, m, "container.net.rcvd.packets", 1)
+	}
+}
+
+// kv represents a key/value pair.
+type kv struct{ K, V string }
+
+// copyMetric copies metric m to dest. The new metric's name will be newname, and all of its datapoints will
+// be divided by div. If filter is provided, only the data points that have *either* of the specified string
+// attributes will be copied over. If the filtering results in no datapoints, no new metric is added to dest.
+//
+// Please note that copyMetric is restricted to the metric types Sum and Gauge.
+func copyMetric(dest pmetric.MetricSlice, m pmetric.Metric, newname string, div float64, filter ...kv) (pmetric.Metric, bool) {
+	newm := pmetric.NewMetric()
+	m.CopyTo(newm)
+	newm.SetName(newname)
+	var dps pmetric.NumberDataPointSlice
+	switch newm.Type() {
+	case pmetric.MetricTypeGauge:
+		dps = newm.Gauge().DataPoints()
+	case pmetric.MetricTypeSum:
+		dps = newm.Sum().DataPoints()
+	default:
+		// invalid metric type
+		return newm, false
+	}
+	dps.RemoveIf(func(dp pmetric.NumberDataPoint) bool {
+		if !hasAny(dp, filter...) {
+			return true
+		}
+		switch dp.ValueType() {
+		case pmetric.NumberDataPointValueTypeInt:
+			dp.SetIntValue(dp.IntValue() / int64(div))
+		case pmetric.NumberDataPointValueTypeDouble:
+			dp.SetDoubleValue(dp.DoubleValue() / div)
+		}
+		return false
+	})
+	if dps.Len() > 0 {
+		// if we have datapoints, copy it
+		addm := dest.AppendEmpty()
+		newm.CopyTo(addm)
+		return addm, true
+	}
+	return newm, false
+}
+
+// hasAny reports whether point has any of the given string tags.
+// If no tags are provided it returns true.
+func hasAny(point pmetric.NumberDataPoint, tags ...kv) bool {
+	if len(tags) == 0 {
+		return true
+	}
+	attr := point.Attributes()
+	for _, tag := range tags {
+		v, ok := attr.Get(tag.K)
+		if !ok {
+			continue
+		}
+		if v.Str() == tag.V {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/otlp/metrics/metrics_remapping.go
+++ b/pkg/otlp/metrics/metrics_remapping.go
@@ -133,6 +133,8 @@ type kv struct{ K, V string }
 // be divided by div. If filter is provided, only the data points that have *either* of the specified string
 // attributes will be copied over. If the filtering results in no datapoints, no new metric is added to dest.
 //
+// copyMetric returns the new metric and reports whether it was added to dest.
+//
 // Please note that copyMetric is restricted to the metric types Sum and Gauge.
 func copyMetric(dest pmetric.MetricSlice, m pmetric.Metric, newname string, div float64, filter ...kv) (pmetric.Metric, bool) {
 	newm := pmetric.NewMetric()

--- a/pkg/otlp/metrics/metrics_remapping_test.go
+++ b/pkg/otlp/metrics/metrics_remapping_test.go
@@ -243,6 +243,14 @@ func TestRemapMetrics(t *testing.T) {
 			},
 		},
 		{
+			in: metric("container.blockio.io_serviced_recursive",
+				point{f: 1, attrs: map[string]any{"xoperation": "write"}},
+				point{f: 2, attrs: map[string]any{"xoperation": "read"}},
+				point{f: 3, attrs: map[string]any{"state": "buffered"}},
+			),
+			out: nil, // no datapoints match filter
+		},
+		{
 			in:  metric("container.network.io.usage.tx_bytes", point{f: 15}),
 			out: []pmetric.Metric{metric("container.net.sent", point{f: 15})},
 		},

--- a/pkg/otlp/metrics/metrics_remapping_test.go
+++ b/pkg/otlp/metrics/metrics_remapping_test.go
@@ -1,0 +1,439 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+)
+
+func TestRemapMetrics(t *testing.T) {
+	// point is a datapoint
+	type point struct {
+		// i defines a IntValue datapoint when non-zero
+		i int64
+		// f defines a DoubleValue datapoint when non-zero
+		f float64
+		// attrs specifies the raw attributes of the datapoint
+		attrs map[string]any
+	}
+	// m is a convenience function to create a new metric with the given name
+	// and set of datapoints
+	metric := func(name string, dps ...point) pmetric.Metric {
+		out := pmetric.NewMetric()
+		out.SetName(name)
+		g := out.SetEmptyGauge()
+		for _, d := range dps {
+			p := g.DataPoints().AppendEmpty()
+			if d.i != 0 {
+				p.SetIntValue(d.i)
+			} else {
+				p.SetDoubleValue(d.f)
+			}
+			p.Attributes().FromRaw(d.attrs)
+		}
+		return out
+	}
+	chunit := func(m pmetric.Metric, typ string) pmetric.Metric {
+		m.SetUnit(typ)
+		return m
+	}
+
+	dest := pmetric.NewMetricSlice()
+	for _, tt := range []struct {
+		in  pmetric.Metric
+		out []pmetric.Metric
+	}{
+		{
+			in:  metric("system.cpu.load_average.1m", point{f: 1}),
+			out: []pmetric.Metric{metric("system.load.1", point{f: 1})},
+		},
+		{
+			in:  metric("system.cpu.load_average.5m", point{f: 5}),
+			out: []pmetric.Metric{metric("system.load.5", point{f: 5})},
+		},
+		{
+			in:  metric("system.cpu.load_average.15m", point{f: 15}),
+			out: []pmetric.Metric{metric("system.load.15", point{f: 15})},
+		},
+		{
+			in: metric("system.cpu.utilization",
+				point{f: 1, attrs: map[string]any{"state": "idle"}},
+				point{f: 2, attrs: map[string]any{"state": "user"}},
+				point{f: 3, attrs: map[string]any{"state": "system"}},
+				point{f: 5, attrs: map[string]any{"state": "wait"}},
+				point{f: 8, attrs: map[string]any{"state": "steal"}},
+				point{f: 13, attrs: map[string]any{"state": "other"}},
+			),
+			out: []pmetric.Metric{
+				metric("system.cpu.idle",
+					point{f: 100, attrs: map[string]any{"state": "idle"}}),
+				metric("system.cpu.user",
+					point{f: 200, attrs: map[string]any{"state": "user"}}),
+				metric("system.cpu.system",
+					point{f: 300, attrs: map[string]any{"state": "system"}}),
+				metric("system.cpu.iowait",
+					point{f: 500, attrs: map[string]any{"state": "wait"}}),
+				metric("system.cpu.stolen",
+					point{f: 800, attrs: map[string]any{"state": "steal"}}),
+			},
+		},
+		{
+			in: metric("system.memory.usage",
+				point{f: divMebibytes * 1, attrs: map[string]any{"state": "free"}},
+				point{f: divMebibytes * 2, attrs: map[string]any{"state": "cached"}},
+				point{f: divMebibytes * 3, attrs: map[string]any{"state": "buffered"}},
+				point{f: divMebibytes * 5, attrs: map[string]any{"state": "steal"}},
+				point{f: divMebibytes * 8, attrs: map[string]any{"state": "system"}},
+				point{f: divMebibytes * 13, attrs: map[string]any{"state": "user"}},
+			),
+			out: []pmetric.Metric{
+				metric("system.mem.total",
+					point{f: 1, attrs: map[string]any{"state": "free"}},
+					point{f: 2, attrs: map[string]any{"state": "cached"}},
+					point{f: 3, attrs: map[string]any{"state": "buffered"}},
+					point{f: 5, attrs: map[string]any{"state": "steal"}},
+					point{f: 8, attrs: map[string]any{"state": "system"}},
+					point{f: 13, attrs: map[string]any{"state": "user"}},
+				),
+				metric("system.mem.usable",
+					point{f: 1, attrs: map[string]any{"state": "free"}},
+					point{f: 2, attrs: map[string]any{"state": "cached"}},
+					point{f: 3, attrs: map[string]any{"state": "buffered"}},
+				),
+			},
+		},
+		{
+			in: metric("system.network.io",
+				point{f: 1, attrs: map[string]any{"direction": "receive"}},
+				point{f: 2, attrs: map[string]any{"direction": "transmit"}},
+				point{f: 3, attrs: map[string]any{"state": "buffered"}},
+			),
+			out: []pmetric.Metric{
+				metric("system.net.bytes_rcvd",
+					point{f: 1, attrs: map[string]any{"direction": "receive"}},
+				),
+				metric("system.net.bytes_sent",
+					point{f: 2, attrs: map[string]any{"direction": "transmit"}},
+				),
+			},
+		},
+		{
+			in: metric("system.paging.usage",
+				point{f: divMebibytes * 1, attrs: map[string]any{"state": "free"}},
+				point{f: divMebibytes * 2, attrs: map[string]any{"state": "used"}},
+				point{f: 3, attrs: map[string]any{"state": "buffered"}},
+			),
+			out: []pmetric.Metric{
+				metric("system.swap.free",
+					point{f: 1, attrs: map[string]any{"state": "free"}},
+				),
+				metric("system.swap.used",
+					point{f: 2, attrs: map[string]any{"state": "used"}},
+				),
+			},
+		},
+		{
+			in:  metric("system.filesystem.utilization", point{f: 15}),
+			out: []pmetric.Metric{metric("system.disk.in_use", point{f: 15})},
+		},
+		{
+			in:  metric("other.metric", point{f: 15}),
+			out: []pmetric.Metric{},
+		},
+		{
+			in: metric("container.cpu.usage.total", point{f: 15}),
+			out: []pmetric.Metric{
+				chunit(metric("container.cpu.usage", point{f: 15}), "nanocore"),
+			},
+		},
+		{
+			in: metric("container.cpu.usage.usermode", point{f: 15}),
+			out: []pmetric.Metric{
+				chunit(metric("container.cpu.user", point{f: 15}), "nanocore"),
+			},
+		},
+		{
+			in: metric("container.cpu.usage.system", point{f: 15}),
+			out: []pmetric.Metric{
+				chunit(metric("container.cpu.system", point{f: 15}), "nanocore"),
+			},
+		},
+		{
+			in:  metric("container.cpu.throttling_data.throttled_time", point{f: 15}),
+			out: []pmetric.Metric{metric("container.cpu.throttled", point{f: 15})},
+		},
+		{
+			in:  metric("container.cpu.throttling_data.throttled_periods", point{f: 15}),
+			out: []pmetric.Metric{metric("container.cpu.throttled.periods", point{f: 15})},
+		},
+		{
+			in:  metric("container.memory.usage.total", point{f: 15}),
+			out: []pmetric.Metric{metric("container.memory.usage", point{f: 15})},
+		},
+		{
+			in:  metric("container.memory.active_anon", point{f: 15}),
+			out: []pmetric.Metric{metric("container.memory.kernel", point{f: 15})},
+		},
+		{
+			in:  metric("container.memory.hierarchical_memory_limit", point{f: 15}),
+			out: []pmetric.Metric{metric("container.memory.limit", point{f: 15})},
+		},
+		{
+			in:  metric("container.memory.usage.limit", point{f: 15}),
+			out: []pmetric.Metric{metric("container.memory.soft_limit", point{f: 15})},
+		},
+		{
+			in:  metric("container.memory.total_cache", point{f: 15}),
+			out: []pmetric.Metric{metric("container.memory.cache", point{f: 15})},
+		},
+		{
+			in:  metric("container.memory.total_swap", point{f: 15}),
+			out: []pmetric.Metric{metric("container.memory.swap", point{f: 15})},
+		},
+		{
+			in: metric("container.blockio.io_service_bytes_recursive",
+				point{f: 1, attrs: map[string]any{"operation": "write"}},
+				point{f: 2, attrs: map[string]any{"operation": "read"}},
+				point{f: 3, attrs: map[string]any{"state": "buffered"}},
+			),
+			out: []pmetric.Metric{
+				metric("container.io.write",
+					point{f: 1, attrs: map[string]any{"operation": "write"}}),
+				metric("container.io.read",
+					point{f: 2, attrs: map[string]any{"operation": "read"}}),
+			},
+		},
+		{
+			in: metric("container.blockio.io_service_bytes_recursive",
+				point{f: 1, attrs: map[string]any{"operation": "write"}},
+			),
+			out: []pmetric.Metric{
+				metric("container.io.write",
+					point{f: 1, attrs: map[string]any{"operation": "write"}}),
+			},
+		},
+		{
+			in: metric("container.blockio.io_serviced_recursive",
+				point{f: 1, attrs: map[string]any{"operation": "write"}},
+				point{f: 2, attrs: map[string]any{"operation": "read"}},
+				point{f: 3, attrs: map[string]any{"state": "buffered"}},
+			),
+			out: []pmetric.Metric{
+				metric("container.io.write.operations",
+					point{f: 1, attrs: map[string]any{"operation": "write"}}),
+				metric("container.io.read.operations",
+					point{f: 2, attrs: map[string]any{"operation": "read"}}),
+			},
+		},
+		{
+			in:  metric("container.network.io.usage.tx_bytes", point{f: 15}),
+			out: []pmetric.Metric{metric("container.net.sent", point{f: 15})},
+		},
+		{
+			in:  metric("container.network.io.usage.tx_packets", point{f: 15}),
+			out: []pmetric.Metric{metric("container.net.sent.packets", point{f: 15})},
+		},
+		{
+			in:  metric("container.network.io.usage.rx_bytes", point{f: 15}),
+			out: []pmetric.Metric{metric("container.net.rcvd", point{f: 15})},
+		},
+		{
+			in:  metric("container.network.io.usage.rx_packets", point{f: 15}),
+			out: []pmetric.Metric{metric("container.net.rcvd.packets", point{f: 15})},
+		},
+	} {
+		lena := dest.Len()
+		checkprefix := strings.HasPrefix(tt.in.Name(), "system.") || strings.HasPrefix(tt.in.Name(), "process.")
+		remapMetrics(dest, tt.in)
+		if checkprefix {
+			require.True(t, strings.HasPrefix(tt.in.Name(), "otel."), "system.* and process.* metrics need to be prepended with the otel.* namespace")
+		}
+		require.Equal(t, dest.Len()-lena, len(tt.out), "unexpected number of metrics added")
+		for i, out := range tt.out {
+			require.Equal(t, out, dest.At(dest.Len()-len(tt.out)+i))
+		}
+	}
+
+}
+
+func TestCopyMetric(t *testing.T) {
+	m := pmetric.NewMetric()
+	m.SetName("test.metric")
+	m.SetDescription("metric-description")
+	m.SetUnit("cm")
+
+	dest := pmetric.NewMetricSlice()
+	t.Run("gauge", func(t *testing.T) {
+		v := m.SetEmptyGauge()
+		dp := v.DataPoints().AppendEmpty()
+		dp.SetDoubleValue(12)
+		dp.Attributes().FromRaw(map[string]any{"fruit": "apple", "count": 15})
+		dp = v.DataPoints().AppendEmpty()
+		dp.SetIntValue(24)
+		dp.Attributes().FromRaw(map[string]any{"human": "Ann", "age": 25})
+
+		t.Run("plain", func(t *testing.T) {
+			out, ok := copyMetric(dest, m, "copied.test.metric", 1)
+			require.True(t, ok)
+			require.Equal(t, m.Name(), "test.metric")
+			require.Equal(t, out.Name(), "copied.test.metric")
+			sameExceptName(t, m, out)
+			require.Equal(t, dest.At(dest.Len()-1), out)
+		})
+
+		t.Run("div", func(t *testing.T) {
+			out, ok := copyMetric(dest, m, "copied.test.metric", 2)
+			require.True(t, ok)
+			require.Equal(t, out.Name(), "copied.test.metric")
+			require.Equal(t, out.Gauge().DataPoints().At(0).DoubleValue(), 6.)
+			require.Equal(t, out.Gauge().DataPoints().At(1).IntValue(), int64(12))
+			require.Equal(t, dest.At(dest.Len()-1), out)
+		})
+
+		t.Run("filter", func(t *testing.T) {
+			out, ok := copyMetric(dest, m, "copied.test.metric", 1, kv{"human", "Ann"})
+			require.True(t, ok)
+			require.Equal(t, out.Name(), "copied.test.metric")
+			require.Equal(t, out.Gauge().DataPoints().Len(), 1)
+			require.Equal(t, out.Gauge().DataPoints().At(0).IntValue(), int64(24))
+			require.Equal(t, out.Gauge().DataPoints().At(0).Attributes().AsRaw(), map[string]any{"human": "Ann", "age": int64(25)})
+			require.Equal(t, dest.At(dest.Len()-1), out)
+		})
+
+		t.Run("none", func(t *testing.T) {
+			_, ok := copyMetric(dest, m, "copied.test.metric", 1, kv{"human", "Paul"})
+			require.False(t, ok)
+		})
+	})
+
+	t.Run("sum", func(t *testing.T) {
+		dp := m.SetEmptySum().DataPoints().AppendEmpty()
+		dp.SetDoubleValue(12)
+		dp.Attributes().FromRaw(map[string]any{"fruit": "apple", "count": 15})
+		out, ok := copyMetric(dest, m, "copied.test.metric", 1)
+		require.True(t, ok)
+		require.Equal(t, out.Name(), "copied.test.metric")
+		sameExceptName(t, m, out)
+		require.Equal(t, dest.At(dest.Len()-1), out)
+	})
+
+	t.Run("histogram", func(t *testing.T) {
+		dp := m.SetEmptyHistogram().DataPoints().AppendEmpty()
+		dp.SetCount(12)
+		dp.SetMax(44)
+		dp.SetMin(3)
+		dp.SetSum(120)
+		_, ok := copyMetric(dest, m, "copied.test.metric", 1)
+		require.False(t, ok)
+	})
+}
+
+func TestHasAny(t *testing.T) {
+	// p returns a numberic data point having the given attributes.
+	p := func(m map[string]any) pmetric.NumberDataPoint {
+		v := pmetric.NewNumberDataPoint()
+		if err := v.Attributes().FromRaw(m); err != nil {
+			t.Fatalf("Error generating data point: %v", err)
+		}
+		return v
+	}
+	for i, tt := range []struct {
+		attrs map[string]any
+		tags  []kv
+		out   bool
+	}{
+		{
+			attrs: map[string]any{
+				"fruit": "apple",
+				"human": "Ann",
+			},
+			tags: []kv{{"human", "Ann"}},
+			out:  true,
+		},
+		{
+			attrs: map[string]any{
+				"fruit": "apple",
+				"human": "Ann",
+			},
+			tags: []kv{{"human", "ann"}},
+			out:  false,
+		},
+		{
+			attrs: map[string]any{
+				"fruit":   "apple",
+				"human":   "Ann",
+				"company": "Paul",
+			},
+			tags: []kv{{"human", "ann"}, {"company", "Paul"}},
+			out:  true,
+		},
+		{
+			attrs: map[string]any{
+				"fruit":   "apple",
+				"human":   "Ann",
+				"company": "Paul",
+			},
+			tags: []kv{{"fruit", "apple"}, {"company", "Paul"}},
+			out:  true,
+		},
+		{
+			attrs: map[string]any{
+				"fruit":   "apple",
+				"human":   "Ann",
+				"company": "Paul",
+			},
+			tags: nil,
+			out:  true,
+		},
+		{
+			attrs: map[string]any{
+				"fruit":   "apple",
+				"human":   "Ann",
+				"company": "Paul",
+				"number":  4,
+			},
+			tags: []kv{{"number", "4"}},
+			out:  false,
+		},
+		{
+			attrs: nil,
+			tags:  []kv{{"number", "4"}},
+			out:   false,
+		},
+		{
+			attrs: nil,
+			tags:  nil,
+			out:   true,
+		},
+	} {
+		require.Equal(t, hasAny(p(tt.attrs), tt.tags...), tt.out, fmt.Sprint(i))
+	}
+}
+
+// sameExceptName validates that metrics a and b are the same by disregarding
+// their names.
+func sameExceptName(t *testing.T, a, b pmetric.Metric) {
+	aa, bb := pmetric.NewMetric(), pmetric.NewMetric()
+	a.CopyTo(aa)
+	b.CopyTo(bb)
+	aa.SetName("🙂")
+	bb.SetName("🙂")
+	require.Equal(t, aa, bb)
+}

--- a/pkg/otlp/metrics/metrics_remapping_test.go
+++ b/pkg/otlp/metrics/metrics_remapping_test.go
@@ -33,7 +33,7 @@ func TestRemapMetrics(t *testing.T) {
 		// attrs specifies the raw attributes of the datapoint
 		attrs map[string]any
 	}
-	// m is a convenience function to create a new metric with the given name
+	// metric is a convenience function to create a new metric with the given name
 	// and set of datapoints
 	metric := func(name string, dps ...point) pmetric.Metric {
 		out := pmetric.NewMetric()
@@ -95,6 +95,10 @@ func TestRemapMetrics(t *testing.T) {
 			},
 		},
 		{
+			in:  metric("system.cpu.utilization", point{i: 5, attrs: map[string]any{"state": "idle"}}),
+			out: []pmetric.Metric{metric("system.cpu.idle", point{i: 5, attrs: map[string]any{"state": "idle"}})},
+		},
+		{
 			in: metric("system.memory.usage",
 				point{f: divMebibytes * 1, attrs: map[string]any{"state": "free"}},
 				point{f: divMebibytes * 2, attrs: map[string]any{"state": "cached"}},
@@ -118,6 +122,10 @@ func TestRemapMetrics(t *testing.T) {
 					point{f: 3, attrs: map[string]any{"state": "buffered"}},
 				),
 			},
+		},
+		{
+			in:  metric("system.memory.usage", point{i: divMebibytes * 5}),
+			out: []pmetric.Metric{metric("system.mem.total", point{i: 5})},
 		},
 		{
 			in: metric("system.network.io",

--- a/pkg/otlp/metrics/metrics_translator.go
+++ b/pkg/otlp/metrics/metrics_translator.go
@@ -590,7 +590,7 @@ func mapHistogramRuntimeMetricWithAttributes(md pmetric.Metric, metricsArray pme
 	}
 }
 
-// MapMetrics maps OTLP metrics into the DataDog format
+// MapMetrics maps OTLP metrics into the Datadog format
 func (t *Translator) MapMetrics(ctx context.Context, md pmetric.Metrics, consumer Consumer) (Metadata, error) {
 	metadata := Metadata{
 		Languages: []string{},
@@ -660,6 +660,9 @@ func (t *Translator) MapMetrics(ctx context.Context, md pmetric.Metrics, consume
 							mapHistogramRuntimeMetricWithAttributes(md, metricsArray, mp)
 						}
 					}
+				}
+				if t.cfg.withRemapping {
+					remapMetrics(metricsArray, md)
 				}
 				baseDims := &Dimensions{
 					name:     md.Name(),


### PR DESCRIPTION
This change adds the processing code for extracting Datadog metrics from container.* and system.* metrics with the intention of centralising this logic to be re-used in the backend intake.

The operation is restricted by the newly added WithRemapping translator configuration option, so that it does not affect the translator's usage as part of the Datadog Agent, where no remapping is necessary because the agent creates the necessary metrics.

Closes #102 