### PR TITLE
Retract v0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,7 @@
 
 ## v0.4.0
 
-### 🛑 Breaking changes 🛑
-
-- `pkg/otlp`: use new location for updated protobuf definitions in the datadog-agent repo, trace protobuf definitions specifically. (#103)
-  new definitions include mutext to avoid copies, and so implementations should rely on passing arguments by reference and not value.
-
-### 💡 Enhancements 💡
-
-- `pkg/otlp/metrics`: A new Translator configuration option (WithRemapping) can be used to extract Datadog system and container metrics. (#102)
+**VERSION HAS BEEN RETRACTED**
 
 ## v0.3.0
 

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -145,7 +145,7 @@ pkg/otlp/attributes,google.golang.org/protobuf/types/descriptorpb,BSD-3-Clause,C
 pkg/otlp/attributes,google.golang.org/protobuf/types/known/anypb,BSD-3-Clause,Copyright (c) 2018 The Go Authors. All rights reserved
 pkg/otlp/attributes,google.golang.org/protobuf/types/known/durationpb,BSD-3-Clause,Copyright (c) 2018 The Go Authors. All rights reserved
 pkg/otlp/attributes,google.golang.org/protobuf/types/known/timestamppb,BSD-3-Clause,Copyright (c) 2018 The Go Authors. All rights reserved
-pkg/otlp/metrics,github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace,Apache-2.0,"Copyright 2016-present Datadog, Inc"
+pkg/otlp/metrics,github.com/DataDog/datadog-agent/pkg/trace/pb,Apache-2.0,"Copyright 2016-present Datadog, Inc"
 pkg/otlp/metrics,github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes,UNKNOWN,"Copyright [2023-Present] Datadog, Inc."
 pkg/otlp/metrics,github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes/azure,UNKNOWN,"Copyright [2023-Present] Datadog, Inc."
 pkg/otlp/metrics,github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes/ec2,UNKNOWN,"Copyright [2023-Present] Datadog, Inc."

--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -202,3 +202,5 @@ require (
 	mvdan.cc/lint v0.0.0-20170908181259-adc824a0674b // indirect
 	mvdan.cc/unparam v0.0.0-20221223090309-7455f1af531d // indirect
 )
+
+retract v0.4.0 // see #107

--- a/pkg/internal/sketchtest/go.mod
+++ b/pkg/internal/sketchtest/go.mod
@@ -9,3 +9,5 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+retract v0.4.0 // see #107

--- a/pkg/otlp/attributes/go.mod
+++ b/pkg/otlp/attributes/go.mod
@@ -23,3 +23,5 @@ require (
 	google.golang.org/protobuf v1.30.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )
+
+retract v0.4.0 // see #107

--- a/pkg/otlp/logs/go.mod
+++ b/pkg/otlp/logs/go.mod
@@ -35,3 +35,5 @@ require (
 )
 
 replace github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes => ../attributes
+
+retract v0.4.0 // see #107

--- a/pkg/otlp/metrics/consumer.go
+++ b/pkg/otlp/metrics/consumer.go
@@ -19,7 +19,7 @@ import (
 	"encoding"
 	"fmt"
 
-	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
+	"github.com/DataDog/datadog-agent/pkg/trace/pb"
 	"github.com/DataDog/opentelemetry-mapping-go/pkg/quantile"
 )
 
@@ -95,7 +95,7 @@ type Consumer interface {
 // a Translator.
 type APMStatsConsumer interface {
 	// ConsumeAPMStats consumes the given StatsPayload.
-	ConsumeAPMStats(*pb.ClientStatsPayload)
+	ConsumeAPMStats(pb.ClientStatsPayload)
 }
 
 // HostConsumer is a hostname consumer.

--- a/pkg/otlp/metrics/go.mod
+++ b/pkg/otlp/metrics/go.mod
@@ -3,7 +3,7 @@ module github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/metrics
 go 1.19
 
 require (
-	github.com/DataDog/datadog-agent/pkg/proto v0.47.0-20230613-devel
+	github.com/DataDog/datadog-agent/pkg/trace v0.45.0
 	github.com/DataDog/opentelemetry-mapping-go/pkg/internal/sketchtest v0.4.0
 	github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes v0.4.0
 	github.com/DataDog/opentelemetry-mapping-go/pkg/quantile v0.4.0

--- a/pkg/otlp/metrics/go.mod
+++ b/pkg/otlp/metrics/go.mod
@@ -44,3 +44,5 @@ replace (
 	github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes => ../attributes
 	github.com/DataDog/opentelemetry-mapping-go/pkg/quantile => ../../quantile
 )
+
+retract v0.4.0 // see #107

--- a/pkg/otlp/metrics/go.sum
+++ b/pkg/otlp/metrics/go.sum
@@ -1,5 +1,5 @@
-github.com/DataDog/datadog-agent/pkg/trace v0.47.0-devel h1:9FRc7ODPoR3HzOuwM0vYbuAjslrb5ePsz0yZjSEIrME=
-github.com/DataDog/datadog-agent/pkg/trace v0.47.0-devel/go.mod h1:4J7X069cl5HXQn0InhQm5yY66MokJs2Mo3ScJBuwUys=
+github.com/DataDog/datadog-agent/pkg/trace v0.45.0 h1:RZCZDyNw7JzbYQxebK1ZXuQvum4usOPHRanD5mZ8um8=
+github.com/DataDog/datadog-agent/pkg/trace v0.45.0/go.mod h1:sMx7fHUAtLbSrUqFjTdKjwfhtUj284HbsttNAzHfsgo=
 github.com/DataDog/sketches-go v1.4.2 h1:gppNudE9d19cQ98RYABOetxIhpTCl4m7CnbRZjvVA/o=
 github.com/DataDog/sketches-go v1.4.2/go.mod h1:xJIXldczJyyjnbDop7ZZcLxJdV3+7Kra7H1KMgpgkLk=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=

--- a/pkg/otlp/metrics/go.sum
+++ b/pkg/otlp/metrics/go.sum
@@ -1,5 +1,5 @@
-github.com/DataDog/datadog-agent/pkg/proto v0.47.0-20230613-devel h1:6c+ZXslKi+krdUXWUDL3w7UvWYG7VQrTM2xMHZhHJ5Y=
-github.com/DataDog/datadog-agent/pkg/proto v0.47.0-20230613-devel/go.mod h1:8mBwY/fPdRcvRJa84NwVJyeO5UbXaBDM9kW3sqH0l0s=
+github.com/DataDog/datadog-agent/pkg/trace v0.47.0-devel h1:9FRc7ODPoR3HzOuwM0vYbuAjslrb5ePsz0yZjSEIrME=
+github.com/DataDog/datadog-agent/pkg/trace v0.47.0-devel/go.mod h1:4J7X069cl5HXQn0InhQm5yY66MokJs2Mo3ScJBuwUys=
 github.com/DataDog/sketches-go v1.4.2 h1:gppNudE9d19cQ98RYABOetxIhpTCl4m7CnbRZjvVA/o=
 github.com/DataDog/sketches-go v1.4.2/go.mod h1:xJIXldczJyyjnbDop7ZZcLxJdV3+7Kra7H1KMgpgkLk=
 github.com/benbjohnson/clock v1.1.0 h1:Q92kusRqC1XV2MjkWETPvjJVqKetz1OzxZB7mHJLju8=
@@ -36,7 +36,7 @@ github.com/patrickmn/go-cache v2.1.0+incompatible h1:HRMgzkcYKYpi3C8ajMPV8OFXaaR
 github.com/patrickmn/go-cache v2.1.0+incompatible/go.mod h1:3Qf8kWWT7OJRJbdiICTKqZju1ZixQ/KpMGzzAfe6+WQ=
 github.com/philhofer/fwd v1.1.2 h1:bnDivRJ1EWPjUIRXV5KfORO897HTbpFAQddBdE8t7Gw=
 github.com/philhofer/fwd v1.1.2/go.mod h1:qkPdfjR2SIEbspLqpe1tO4n5yICnr2DY7mqEx2tUTP0=
-github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
@@ -47,6 +47,8 @@ github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcU
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
 github.com/tinylib/msgp v1.1.8 h1:FCXC1xanKO4I8plpHGH2P7koL/RzZs12l/+r7vakfm0=
 github.com/tinylib/msgp v1.1.8/go.mod h1:qkpG+2ldGg4xRFmx+jfTvZPxfGFhi64BcnL9vkCm/Tw=
+github.com/vmihailenco/msgpack/v4 v4.3.12 h1:07s4sz9IReOgdikxLTKNbBdqDMLsjPKXwvCazn8G65U=
+github.com/vmihailenco/tagparser v0.1.2 h1:gnjoVuB/kljJ5wICEEOpx98oXMWPLj22G67Vbd1qPqc=
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
@@ -114,6 +116,7 @@ golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8T
 golang.org/x/xerrors v0.0.0-20191011141410-1b5146add898/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+google.golang.org/appengine v1.6.7 h1:FZR1q0exgwxzPzp/aF+VccGrSfxfPpkBqjIIEq3ru6c=
 google.golang.org/genproto v0.0.0-20230410155749-daa745c078e1 h1:KpwkzHKEF7B9Zxg18WzOa7djJ+Ha5DzthMyZYQfEn2A=
 google.golang.org/genproto v0.0.0-20230410155749-daa745c078e1/go.mod h1:nKE/iIaLqn2bQwXBg8f1g2Ylh6r5MN5CmZvuzZCgsCU=
 google.golang.org/grpc v1.55.0 h1:3Oj82/tFSCeUrRTg/5E/7d/W5A1tj6Ky1ABAuZuv5ag=

--- a/pkg/otlp/metrics/metrics_translator_test.go
+++ b/pkg/otlp/metrics/metrics_translator_test.go
@@ -26,7 +26,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.uber.org/zap"
 
-	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
+	"github.com/DataDog/datadog-agent/pkg/trace/pb"
 	"github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes/source"
 	"github.com/DataDog/opentelemetry-mapping-go/pkg/quantile"
 	"github.com/DataDog/opentelemetry-mapping-go/pkg/quantile/summary"
@@ -829,8 +829,8 @@ func TestMapAPMStats(t *testing.T) {
 	logger, err := zap.NewDevelopment()
 	require.NoError(t, err)
 	tr := newTranslator(t, logger)
-	md := tr.StatsPayloadToMetrics(&pb.StatsPayload{
-		Stats: []*pb.ClientStatsPayload{statsPayloads[0], statsPayloads[1]},
+	md := tr.StatsPayloadToMetrics(pb.StatsPayload{
+		Stats: []pb.ClientStatsPayload{statsPayloads[0], statsPayloads[1]},
 	})
 
 	ctx := context.Background()
@@ -888,10 +888,10 @@ var _ SketchConsumer = (*mockFullConsumer)(nil)
 type mockFullConsumer struct {
 	mockTimeSeriesConsumer
 	sketches []sketch
-	apmstats []*pb.ClientStatsPayload
+	apmstats []pb.ClientStatsPayload
 }
 
-func (c *mockFullConsumer) ConsumeAPMStats(p *pb.ClientStatsPayload) {
+func (c *mockFullConsumer) ConsumeAPMStats(p pb.ClientStatsPayload) {
 	c.apmstats = append(c.apmstats, p)
 }
 
@@ -1107,7 +1107,7 @@ func newSketchWithHostname(name string, summary summary.Summary, tags []string) 
 	return s
 }
 
-var statsPayloads = []*pb.ClientStatsPayload{
+var statsPayloads = []pb.ClientStatsPayload{
 	{
 		Hostname:         "host",
 		Env:              "prod",
@@ -1120,11 +1120,11 @@ var statsPayloads = []*pb.ClientStatsPayload{
 		Service:          "mysql",
 		ContainerID:      "abcdef123456",
 		Tags:             []string{"a:b", "c:d"},
-		Stats: []*pb.ClientStatsBucket{
+		Stats: []pb.ClientStatsBucket{
 			{
 				Start:    10,
 				Duration: 1,
-				Stats: []*pb.ClientGroupedStats{
+				Stats: []pb.ClientGroupedStats{
 					{
 						Service:        "kafka",
 						Name:           "queue.add",
@@ -1154,11 +1154,11 @@ var statsPayloads = []*pb.ClientStatsPayload{
 		Service:          "mysql2",
 		ContainerID:      "abcdef1234562",
 		Tags:             []string{"a:b2", "c:d2"},
-		Stats: []*pb.ClientStatsBucket{
+		Stats: []pb.ClientStatsBucket{
 			{
 				Start:    102,
 				Duration: 12,
-				Stats: []*pb.ClientGroupedStats{
+				Stats: []pb.ClientGroupedStats{
 					{
 						Service:        "kafka2",
 						Name:           "queue.add2",

--- a/pkg/otlp/metrics/sketches_test.go
+++ b/pkg/otlp/metrics/sketches_test.go
@@ -28,7 +28,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.uber.org/zap"
 
-	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
+	"github.com/DataDog/datadog-agent/pkg/trace/pb"
 	"github.com/DataDog/opentelemetry-mapping-go/pkg/internal/sketchtest"
 	"github.com/DataDog/opentelemetry-mapping-go/pkg/quantile"
 )
@@ -40,7 +40,7 @@ type sketchConsumer struct {
 	sk *quantile.Sketch
 }
 
-func (c *sketchConsumer) ConsumeAPMStats(_ *pb.ClientStatsPayload) {
+func (c *sketchConsumer) ConsumeAPMStats(_ pb.ClientStatsPayload) {
 	// not used for this consumer, but do warn the user if they
 	// try to use it
 	panic("(*sketchConsumer).ConsumeAPMStats not implemented")

--- a/pkg/otlp/metrics/statspayload.go
+++ b/pkg/otlp/metrics/statspayload.go
@@ -27,7 +27,7 @@ import (
 	"go.opentelemetry.io/collector/pdata/pmetric"
 	"go.uber.org/zap"
 
-	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
+	"github.com/DataDog/datadog-agent/pkg/trace/pb"
 	"github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes/source"
 )
 
@@ -68,7 +68,7 @@ const (
 )
 
 // StatsPayloadToMetrics converts an APM Stats Payload to a set of OTLP Metrics.
-func (t *Translator) StatsPayloadToMetrics(sp *pb.StatsPayload) pmetric.Metrics {
+func (t *Translator) StatsPayloadToMetrics(sp pb.StatsPayload) pmetric.Metrics {
 	mmx := pmetric.NewMetrics()
 	// We ignore Agent{Hostname,Env,Version} and fill those in later. We want those
 	// values to be consistent with the ones that appear on traces and logs. They are
@@ -103,12 +103,12 @@ func (t *Translator) StatsPayloadToMetrics(sp *pb.StatsPayload) pmetric.Metrics 
 					metricNameDuration:     cgs.Duration,
 					metricNameTopLevelHits: cgs.TopLevelHits,
 				} {
-					appendSum(mxs, name, int64(val), sb.Start, sb.Start+sb.Duration, cgs)
+					appendSum(mxs, name, int64(val), sb.Start, sb.Start+sb.Duration, &cgs)
 				}
-				if err := appendSketch(mxs, metricNameOkSummary, cgs.OkSummary, sb.Start, sb.Start+sb.Duration, cgs); err != nil {
+				if err := appendSketch(mxs, metricNameOkSummary, cgs.OkSummary, sb.Start, sb.Start+sb.Duration, &cgs); err != nil {
 					t.logger.Error("Error exporting APM Stats ok_summary", zap.Error(err))
 				}
-				if err := appendSketch(mxs, metricNameErrorSummary, cgs.ErrorSummary, sb.Start, sb.Start+sb.Duration, cgs); err != nil {
+				if err := appendSketch(mxs, metricNameErrorSummary, cgs.ErrorSummary, sb.Start, sb.Start+sb.Duration, &cgs); err != nil {
 					t.logger.Error("Error exporting APM Stats error_summary", zap.Error(err))
 				}
 			}
@@ -286,10 +286,10 @@ func (a *aggregations) Value(m pcommon.Map) *aggregationValue {
 
 // Stats returns the set of pb.ClientGroupedStats based on all the aggregated key/value
 // pairs.
-func (a *aggregations) Stats() []*pb.ClientGroupedStats {
-	cgs := make([]*pb.ClientGroupedStats, 0, len(a.agg))
+func (a *aggregations) Stats() []pb.ClientGroupedStats {
+	cgs := make([]pb.ClientGroupedStats, 0, len(a.agg))
 	for k, v := range a.agg {
-		cgs = append(cgs, &pb.ClientGroupedStats{
+		cgs = append(cgs, pb.ClientGroupedStats{
 			Service:        k.Service,
 			Name:           k.Name,
 			Resource:       k.Resource,
@@ -319,17 +319,17 @@ func (a *aggregations) Stats() []*pb.ClientGroupedStats {
 const UnsetHostnamePlaceholder = "__unset__"
 
 // statsPayloadFromMetrics converts Resource Metrics to an APM Client Stats Payload.
-func (t *Translator) statsPayloadFromMetrics(rmx pmetric.ResourceMetrics) (*pb.ClientStatsPayload, error) {
+func (t *Translator) statsPayloadFromMetrics(rmx pmetric.ResourceMetrics) (pb.ClientStatsPayload, error) {
 	attr := rmx.Resource().Attributes()
 	if v, ok := attr.Get(keyAPMStats); !ok || !v.Bool() {
-		return &pb.ClientStatsPayload{}, fmt.Errorf("was asked to convert metrics to stats payload, but identifier key %q was not present. Skipping.", keyAPMStats)
+		return pb.ClientStatsPayload{}, fmt.Errorf("was asked to convert metrics to stats payload, but identifier key %q was not present. Skipping.", keyAPMStats)
 	}
 	hostname := getStr(attr, statsKeyHostname)
 	tags := strings.Split(getStr(attr, statsKeyTags), ",")
 	if hostname == UnsetHostnamePlaceholder {
 		src, err := t.source(attr)
 		if err != nil {
-			return &pb.ClientStatsPayload{}, err
+			return pb.ClientStatsPayload{}, err
 		}
 		switch src.Kind {
 		case source.HostnameKind:
@@ -339,7 +339,7 @@ func (t *Translator) statsPayloadFromMetrics(rmx pmetric.ResourceMetrics) (*pb.C
 			tags = append(tags, src.Tag())
 		}
 	}
-	cp := &pb.ClientStatsPayload{
+	cp := pb.ClientStatsPayload{
 		Hostname:         hostname,
 		Env:              getStr(attr, statsKeyEnv),
 		Version:          getStr(attr, statsKeyVersion),
@@ -383,11 +383,11 @@ func (t *Translator) statsPayloadFromMetrics(rmx pmetric.ResourceMetrics) (*pb.C
 					agg.Value(key).ErrorSummary = val
 				}
 			default:
-				return &pb.ClientStatsPayload{}, fmt.Errorf(`metric named %q in Stats Payload should be of type "Sum" or "ExponentialHistogram" but is %q instead`, m.Name(), m.Type())
+				return pb.ClientStatsPayload{}, fmt.Errorf(`metric named %q in Stats Payload should be of type "Sum" or "ExponentialHistogram" but is %q instead`, m.Name(), m.Type())
 			}
 		}
 		buck.Stats = agg.Stats()
-		cp.Stats = append(cp.Stats, &buck)
+		cp.Stats = append(cp.Stats, buck)
 	}
 	return cp, nil
 }

--- a/pkg/otlp/metrics/statspayload_test.go
+++ b/pkg/otlp/metrics/statspayload_test.go
@@ -17,7 +17,7 @@ package metrics
 import (
 	"testing"
 
-	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
+	"github.com/DataDog/datadog-agent/pkg/trace/pb"
 	"github.com/DataDog/sketches-go/ddsketch"
 	"github.com/DataDog/sketches-go/ddsketch/store"
 	"github.com/golang/protobuf/proto"
@@ -169,7 +169,7 @@ func TestAggregations(t *testing.T) {
 	require.True(t, val1 != agg.Value(m2))
 	require.NotEqual(t, val1, agg.Value(m2))
 
-	require.ElementsMatch(t, agg.Stats(), []*pb.ClientGroupedStats{
+	require.ElementsMatch(t, agg.Stats(), []pb.ClientGroupedStats{
 		{
 			Service:        "my-service",
 			Name:           "my-name",
@@ -355,8 +355,8 @@ func testSketchBytes(nums ...float64) []byte {
 }
 
 func TestConversion(t *testing.T) {
-	want := &pb.StatsPayload{
-		Stats: []*pb.ClientStatsPayload{
+	want := pb.StatsPayload{
+		Stats: []pb.ClientStatsPayload{
 			{
 				Hostname:         "host",
 				Env:              "prod",
@@ -369,11 +369,11 @@ func TestConversion(t *testing.T) {
 				Service:          "mysql",
 				ContainerID:      "abcdef123456",
 				Tags:             []string{"a:b", "c:d"},
-				Stats: []*pb.ClientStatsBucket{
+				Stats: []pb.ClientStatsBucket{
 					{
 						Start:    10,
 						Duration: 1,
-						Stats: []*pb.ClientGroupedStats{
+						Stats: []pb.ClientGroupedStats{
 							{
 								Service:        "mysql",
 								Name:           "db.query",
@@ -407,7 +407,7 @@ func TestConversion(t *testing.T) {
 					{
 						Start:    20,
 						Duration: 3,
-						Stats: []*pb.ClientGroupedStats{
+						Stats: []pb.ClientGroupedStats{
 							{
 								Service:        "php-go",
 								Name:           "http.post",
@@ -437,11 +437,11 @@ func TestConversion(t *testing.T) {
 				Service:          "sprint",
 				ContainerID:      "kljdsfalk32",
 				Tags:             []string{"x:y", "z:w"},
-				Stats: []*pb.ClientStatsBucket{
+				Stats: []pb.ClientStatsBucket{
 					{
 						Start:    30,
 						Duration: 5,
-						Stats: []*pb.ClientGroupedStats{
+						Stats: []pb.ClientGroupedStats{
 							{
 								Service:        "spring-web",
 								Name:           "http.get",
@@ -490,7 +490,7 @@ func TestConversion(t *testing.T) {
 	})
 }
 
-func equalStats(want, got *pb.ClientStatsPayload) bool {
+func equalStats(want, got pb.ClientStatsPayload) bool {
 	cpwant, cpgot := want, got
 	cpwant.Stats = nil
 	cpgot.Stats = nil

--- a/pkg/otlp/metrics/testhelper_test.go
+++ b/pkg/otlp/metrics/testhelper_test.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 	"testing"
 
-	pb "github.com/DataDog/datadog-agent/pkg/proto/pbgo/trace"
+	"github.com/DataDog/datadog-agent/pkg/trace/pb"
 	"github.com/DataDog/opentelemetry-mapping-go/pkg/quantile"
 	"github.com/DataDog/opentelemetry-mapping-go/pkg/quantile/summary"
 	"github.com/stretchr/testify/assert"
@@ -118,7 +118,7 @@ type testConsumer struct {
 	testMetrics TestMetrics
 }
 
-func (t *testConsumer) ConsumeAPMStats(_ *pb.ClientStatsPayload) {
+func (t *testConsumer) ConsumeAPMStats(_ pb.ClientStatsPayload) {
 	// not used for this consumer, but do warn the user if they
 	// try to use it
 	panic("(*testConsumer).ConsumeAPMStats not implemented")

--- a/pkg/quantile/go.mod
+++ b/pkg/quantile/go.mod
@@ -17,3 +17,5 @@ require (
 )
 
 replace github.com/DataDog/opentelemetry-mapping-go/pkg/internal/sketchtest => ../internal/sketchtest
+
+retract v0.4.0 // see #107


### PR DESCRIPTION
This change retracts v0.4.0 and reverts #103.

#103 shouldn't have been released. It is blocking us from updating the contrib collector because pkg/trace in datadog-agent isn't updated with these changes. Furthermore, those changes aren't yet out.