### PR TITLE
[pkg/otlp/metrics] Add WithInitialValueMode to metrics translator

### DIFF
--- a/.chloggen/mx-psi_counter-mode.yaml
+++ b/.chloggen/mx-psi_counter-mode.yaml
@@ -5,7 +5,7 @@ change_type: enhancement
 component: pkg/otlp/metrics
 
 # A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Add WithInitialValueMode option to metrics translator to configure behavior when exporting cumulative monotonic sums under the 'cumulative_to_delta' mode
+note: Add WithInitialCumulMonoValueMode option to metrics translator to configure behavior when exporting cumulative monotonic sums under the 'cumulative_to_delta' mode
 
 # The PR related to this change
 issues: [109]

--- a/.chloggen/mx-psi_counter-mode.yaml
+++ b/.chloggen/mx-psi_counter-mode.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component (e.g. pkg/quantile)
+component: pkg/otlp/metrics
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add WithInitialValueMode option to metrics translator to configure behavior when exporting cumulative monotonic sums under the 'cumulative_to_delta' mode
+
+# The PR related to this change
+issues: [109]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/pkg/otlp/metrics/config.go
+++ b/pkg/otlp/metrics/config.go
@@ -25,7 +25,7 @@ type translatorConfig struct {
 	HistMode                  HistogramMode
 	SendHistogramAggregations bool
 	Quantiles                 bool
-	SendMonotonic             bool
+	NumberMode                NumberMode
 	ResourceAttributesAsTags  bool
 	// Deprecated: use InstrumentationScopeMetadataAsTags instead in favor of
 	// https://github.com/open-telemetry/opentelemetry-proto/releases/tag/v0.15.0
@@ -177,14 +177,7 @@ const (
 // The default mode is NumberModeCumulativeToDelta.
 func WithNumberMode(mode NumberMode) TranslatorOption {
 	return func(t *translatorConfig) error {
-		switch mode {
-		case NumberModeCumulativeToDelta:
-			t.SendMonotonic = true
-		case NumberModeRawValue:
-			t.SendMonotonic = false
-		default:
-			return fmt.Errorf("unknown number mode: %q", mode)
-		}
+		t.NumberMode = mode
 		return nil
 	}
 }

--- a/pkg/otlp/metrics/config.go
+++ b/pkg/otlp/metrics/config.go
@@ -193,7 +193,7 @@ const (
 	// is set and it happens after the process was started.
 	InitialCumulMonoValueModeAuto InitialCumulMonoValueMode = "auto"
 
-	// InitialCumulMonoModeDrop always drops the initial value.
+	// InitialCumulMonoValueModeDrop always drops the initial value.
 	InitialCumulMonoValueModeDrop InitialCumulMonoValueMode = "drop"
 
 	// InitialCumulMonoValueModeKeep always reports the initial value.

--- a/pkg/otlp/metrics/config.go
+++ b/pkg/otlp/metrics/config.go
@@ -26,6 +26,7 @@ type translatorConfig struct {
 	SendHistogramAggregations bool
 	Quantiles                 bool
 	NumberMode                NumberMode
+	InitialValueMode          InitialValueMode
 	ResourceAttributesAsTags  bool
 	// Deprecated: use InstrumentationScopeMetadataAsTags instead in favor of
 	// https://github.com/open-telemetry/opentelemetry-proto/releases/tag/v0.15.0
@@ -178,6 +179,32 @@ const (
 func WithNumberMode(mode NumberMode) TranslatorOption {
 	return func(t *translatorConfig) error {
 		t.NumberMode = mode
+		return nil
+	}
+}
+
+// InitialValueMode defines what the exporter should do with the initial value
+// of a cumulative monotonic sum when under the 'cumulative_to_delta' mode.
+// It is not used when the mode is 'raw_value'.
+type InitialValueMode string
+
+const (
+	// InitialValueModeAuto reports the initial value if its start timestamp
+	// is set and it happens after the process was started.
+	InitialValueModeAuto InitialValueMode = "auto"
+
+	// InitialValueModeDrop always drops the initial value.
+	InitialValueModeDrop InitialValueMode = "drop"
+
+	// InitialValueModeKeep always reports the initial value.
+	InitialValueModeKeep InitialValueMode = "keep"
+)
+
+// WithInitialValueMode sets the initial value mode.
+// The default mode is InitialValueModeAuto.
+func WithInitialValueMode(mode InitialValueMode) TranslatorOption {
+	return func(t *translatorConfig) error {
+		t.InitialValueMode = mode
 		return nil
 	}
 }

--- a/pkg/otlp/metrics/config.go
+++ b/pkg/otlp/metrics/config.go
@@ -26,7 +26,7 @@ type translatorConfig struct {
 	SendHistogramAggregations bool
 	Quantiles                 bool
 	NumberMode                NumberMode
-	InitialValueMode          InitialValueMode
+	InitialCumulMonoValueMode InitialCumulMonoValueMode
 	ResourceAttributesAsTags  bool
 	// Deprecated: use InstrumentationScopeMetadataAsTags instead in favor of
 	// https://github.com/open-telemetry/opentelemetry-proto/releases/tag/v0.15.0
@@ -183,28 +183,28 @@ func WithNumberMode(mode NumberMode) TranslatorOption {
 	}
 }
 
-// InitialValueMode defines what the exporter should do with the initial value
+// InitialCumulMonoValueMode defines what the exporter should do with the initial value
 // of a cumulative monotonic sum when under the 'cumulative_to_delta' mode.
 // It is not used when the mode is 'raw_value'.
-type InitialValueMode string
+type InitialCumulMonoValueMode string
 
 const (
-	// InitialValueModeAuto reports the initial value if its start timestamp
+	// InitialCumulMonoValueModeAuto reports the initial value if its start timestamp
 	// is set and it happens after the process was started.
-	InitialValueModeAuto InitialValueMode = "auto"
+	InitialCumulMonoValueModeAuto InitialCumulMonoValueMode = "auto"
 
-	// InitialValueModeDrop always drops the initial value.
-	InitialValueModeDrop InitialValueMode = "drop"
+	// InitialCumulMonoModeDrop always drops the initial value.
+	InitialCumulMonoValueModeDrop InitialCumulMonoValueMode = "drop"
 
-	// InitialValueModeKeep always reports the initial value.
-	InitialValueModeKeep InitialValueMode = "keep"
+	// InitialCumulMonoValueModeKeep always reports the initial value.
+	InitialCumulMonoValueModeKeep InitialCumulMonoValueMode = "keep"
 )
 
-// WithInitialValueMode sets the initial value mode.
-// The default mode is InitialValueModeAuto.
-func WithInitialValueMode(mode InitialValueMode) TranslatorOption {
+// WithInitialCumulMonoValueMode sets the initial value mode.
+// The default mode is InitialCumulMonoValueModeAuto.
+func WithInitialCumulMonoValueMode(mode InitialCumulMonoValueMode) TranslatorOption {
 	return func(t *translatorConfig) error {
-		t.InitialValueMode = mode
+		t.InitialCumulMonoValueMode = mode
 		return nil
 	}
 }

--- a/pkg/otlp/metrics/metrics_translator.go
+++ b/pkg/otlp/metrics/metrics_translator.go
@@ -179,10 +179,10 @@ func (t *Translator) mapNumberMonotonicMetrics(
 
 		if dx, ok := t.prevPts.MonotonicDiff(pointDims, startTs, ts, val); ok {
 			consumer.ConsumeTimeSeries(ctx, pointDims, Count, ts, dx)
-		} else {
+		} else if i == 0 {
 			switch t.cfg.InitialCumulMonoValueMode {
 			case InitialCumulMonoValueModeAuto:
-				if i == 0 && getProcessStartTime() < startTs && startTs != ts {
+				if getProcessStartTime() < startTs && startTs != ts {
 					// Report the first value if the timeseries started after the Datadog Agent process started.
 					consumer.ConsumeTimeSeries(ctx, pointDims, Count, ts, val)
 				}

--- a/pkg/otlp/metrics/metrics_translator.go
+++ b/pkg/otlp/metrics/metrics_translator.go
@@ -68,7 +68,7 @@ func NewTranslator(logger *zap.Logger, options ...TranslatorOption) (*Translator
 		SendHistogramAggregations:            false,
 		Quantiles:                            false,
 		NumberMode:                           NumberModeCumulativeToDelta,
-		InitialValueMode:                     InitialValueModeAuto,
+		InitialCumulMonoValueMode:            InitialCumulMonoValueModeAuto,
 		ResourceAttributesAsTags:             false,
 		InstrumentationLibraryMetadataAsTags: false,
 		sweepInterval:                        1800,
@@ -180,15 +180,15 @@ func (t *Translator) mapNumberMonotonicMetrics(
 		if dx, ok := t.prevPts.MonotonicDiff(pointDims, startTs, ts, val); ok {
 			consumer.ConsumeTimeSeries(ctx, pointDims, Count, ts, dx)
 		} else {
-			switch t.cfg.InitialValueMode {
-			case InitialValueModeAuto:
+			switch t.cfg.InitialCumulMonoValueMode {
+			case InitialCumulMonoValueModeAuto:
 				if i == 0 && getProcessStartTime() < startTs && startTs != ts {
 					// Report the first value if the timeseries started after the Datadog Agent process started.
 					consumer.ConsumeTimeSeries(ctx, pointDims, Count, ts, val)
 				}
-			case InitialValueModeKeep:
+			case InitialCumulMonoValueModeKeep:
 				consumer.ConsumeTimeSeries(ctx, pointDims, Count, ts, val)
-			case InitialValueModeDrop:
+			case InitialCumulMonoValueModeDrop:
 				// do nothing, drop the point
 			}
 		}

--- a/pkg/otlp/metrics/metrics_translator.go
+++ b/pkg/otlp/metrics/metrics_translator.go
@@ -152,6 +152,23 @@ func getProcessStartTime() uint64 {
 	return startTime
 }
 
+// shouldConsumeInitialValue checks if the initial value of a cumulative monotonic metric
+// should be consumed or dropped.
+func (t *Translator) shouldConsumeInitialValue(startTs, ts uint64) bool {
+	switch t.cfg.InitialCumulMonoValueMode {
+	case InitialCumulMonoValueModeAuto:
+		if getProcessStartTime() < startTs && startTs != ts {
+			// Report the first value if the timeseries started after the Datadog Agent process started.
+			return true
+		}
+	case InitialCumulMonoValueModeKeep:
+		return true
+	case InitialCumulMonoValueModeDrop:
+		// do nothing, drop the point
+	}
+	return false
+}
+
 // mapNumberMonotonicMetrics maps monotonic datapoints into Datadog metrics
 func (t *Translator) mapNumberMonotonicMetrics(
 	ctx context.Context,
@@ -179,18 +196,8 @@ func (t *Translator) mapNumberMonotonicMetrics(
 
 		if dx, ok := t.prevPts.MonotonicDiff(pointDims, startTs, ts, val); ok {
 			consumer.ConsumeTimeSeries(ctx, pointDims, Count, ts, dx)
-		} else if i == 0 {
-			switch t.cfg.InitialCumulMonoValueMode {
-			case InitialCumulMonoValueModeAuto:
-				if getProcessStartTime() < startTs && startTs != ts {
-					// Report the first value if the timeseries started after the Datadog Agent process started.
-					consumer.ConsumeTimeSeries(ctx, pointDims, Count, ts, val)
-				}
-			case InitialCumulMonoValueModeKeep:
-				consumer.ConsumeTimeSeries(ctx, pointDims, Count, ts, val)
-			case InitialCumulMonoValueModeDrop:
-				// do nothing, drop the point
-			}
+		} else if i == 0 && t.shouldConsumeInitialValue(startTs, ts) {
+			consumer.ConsumeTimeSeries(ctx, pointDims, Count, ts, val)
 		}
 	}
 }

--- a/pkg/otlp/metrics/mixed_metrics_test.go
+++ b/pkg/otlp/metrics/mixed_metrics_test.go
@@ -118,6 +118,26 @@ func TestMapMetrics(t *testing.T) {
 			expectedUnknownMetricType:                 1,
 			expectedUnsupportedAggregationTemporality: 2,
 		},
+		{
+			name:     "with-initial-value-keep",
+			otlpfile: "testdata/otlpdata/mixed/simple.json",
+			ddogfile: "testdata/datadogdata/mixed/simple_keep.json",
+			options: []TranslatorOption{
+				WithInitialValueMode(InitialValueModeKeep),
+			},
+			expectedUnknownMetricType:                 1,
+			expectedUnsupportedAggregationTemporality: 2,
+		},
+		{
+			name:     "with-initial-value-drop",
+			otlpfile: "testdata/otlpdata/mixed/simple.json",
+			ddogfile: "testdata/datadogdata/mixed/simple_drop.json",
+			options: []TranslatorOption{
+				WithInitialValueMode(InitialValueModeDrop),
+			},
+			expectedUnknownMetricType:                 1,
+			expectedUnsupportedAggregationTemporality: 2,
+		},
 	}
 
 	for _, testinstance := range tests {

--- a/pkg/otlp/metrics/mixed_metrics_test.go
+++ b/pkg/otlp/metrics/mixed_metrics_test.go
@@ -123,7 +123,7 @@ func TestMapMetrics(t *testing.T) {
 			otlpfile: "testdata/otlpdata/mixed/simple.json",
 			ddogfile: "testdata/datadogdata/mixed/simple_keep.json",
 			options: []TranslatorOption{
-				WithInitialValueMode(InitialValueModeKeep),
+				WithInitialCumulMonoValueMode(InitialCumulMonoValueModeKeep),
 			},
 			expectedUnknownMetricType:                 1,
 			expectedUnsupportedAggregationTemporality: 2,
@@ -133,7 +133,7 @@ func TestMapMetrics(t *testing.T) {
 			otlpfile: "testdata/otlpdata/mixed/simple.json",
 			ddogfile: "testdata/datadogdata/mixed/simple_drop.json",
 			options: []TranslatorOption{
-				WithInitialValueMode(InitialValueModeDrop),
+				WithInitialCumulMonoValueMode(InitialCumulMonoValueModeDrop),
 			},
 			expectedUnknownMetricType:                 1,
 			expectedUnsupportedAggregationTemporality: 2,

--- a/pkg/otlp/metrics/testdata/datadogdata/mixed/simple_drop.json
+++ b/pkg/otlp/metrics/testdata/datadogdata/mixed/simple_drop.json
@@ -1,0 +1,173 @@
+{
+    "Sketches": [
+      {
+        "Name": "double.histogram",
+        "Tags": [
+          "custom_attribute:custom_value",
+          "deployment.environment:dev"
+        ],
+        "Host": "res-hostname",
+        "OriginID": "",
+        "Timestamp": 1667560641226420924,
+        "Summary": {
+          "Min": 0,
+          "Max": 0,
+          "Sum": 1.618033988749895,
+          "Avg": 0.08090169943749474,
+          "Cnt": 20
+        },
+        "Keys": [
+          0
+        ],
+        "Counts": [
+          20
+        ]
+      }
+    ],
+    "TimeSeries": [
+      {
+        "Name": "int.gauge",
+        "Tags": [
+          "custom_attribute:custom_value",
+          "deployment.environment:dev"
+        ],
+        "Host": "res-hostname",
+        "OriginID": "",
+        "Type": "gauge",
+        "Timestamp": 1667560641226420924,
+        "Value": 1
+      },
+      {
+        "Name": "double.gauge",
+        "Tags": [
+          "custom_attribute:custom_value",
+          "deployment.environment:dev"
+        ],
+        "Host": "res-hostname",
+        "OriginID": "",
+        "Type": "gauge",
+        "Timestamp": 1667560641226420924,
+        "Value": 3.141592653589793
+      },
+      {
+        "Name": "int.delta.sum",
+        "Tags": [
+          "custom_attribute:custom_value",
+          "deployment.environment:dev"
+        ],
+        "Host": "res-hostname",
+        "OriginID": "",
+        "Type": "count",
+        "Timestamp": 1667560641226420924,
+        "Value": 2
+      },
+      {
+        "Name": "double.delta.sum",
+        "Tags": [
+          "custom_attribute:custom_value",
+          "deployment.environment:dev"
+        ],
+        "Host": "res-hostname",
+        "OriginID": "",
+        "Type": "count",
+        "Timestamp": 1667560641226420924,
+        "Value": 2.718281828459045
+      },
+      {
+        "Name": "int.delta.monotonic.sum",
+        "Tags": [
+          "custom_attribute:custom_value",
+          "deployment.environment:dev"
+        ],
+        "Host": "res-hostname",
+        "OriginID": "",
+        "Type": "count",
+        "Timestamp": 1667560641226420924,
+        "Value": 2
+      },
+      {
+        "Name": "double.delta.monotonic.sum",
+        "Tags": [
+          "custom_attribute:custom_value",
+          "deployment.environment:dev"
+        ],
+        "Host": "res-hostname",
+        "OriginID": "",
+        "Type": "count",
+        "Timestamp": 1667560641226420924,
+        "Value": 2.718281828459045
+      },
+      {
+        "Name": "int.cumulative.sum",
+        "Tags": [
+          "custom_attribute:custom_value",
+          "deployment.environment:dev"
+        ],
+        "Host": "res-hostname",
+        "OriginID": "",
+        "Type": "gauge",
+        "Timestamp": 1667560641226420924,
+        "Value": 4
+      },
+      {
+        "Name": "double.cumulative.sum",
+        "Tags": [
+          "custom_attribute:custom_value",
+          "deployment.environment:dev"
+        ],
+        "Host": "res-hostname",
+        "OriginID": "",
+        "Type": "gauge",
+        "Timestamp": 1667560641226420924,
+        "Value": 4
+      },
+      {
+        "Name": "int.cumulative.monotonic.sum",
+        "Tags": [
+          "custom_attribute:custom_value",
+          "deployment.environment:dev"
+        ],
+        "Host": "res-hostname",
+        "OriginID": "",
+        "Type": "count",
+        "Timestamp": 1667560641226420925,
+        "Value": 3
+      },
+      {
+        "Name": "double.cumulative.monotonic.sum",
+        "Tags": [
+          "custom_attribute:custom_value",
+          "deployment.environment:dev"
+        ],
+        "Host": "res-hostname",
+        "OriginID": "",
+        "Type": "count",
+        "Timestamp": 1667560641226420925,
+        "Value": 3
+      },
+      {
+        "Name": "summary.count",
+        "Tags": [
+          "custom_attribute:custom_value",
+          "deployment.environment:dev"
+        ],
+        "Host": "res-hostname",
+        "OriginID": "",
+        "Type": "count",
+        "Timestamp": 1667560641226420925,
+        "Value": 100
+      },
+      {
+        "Name": "summary.sum",
+        "Tags": [
+          "custom_attribute:custom_value",
+          "deployment.environment:dev"
+        ],
+        "Host": "res-hostname",
+        "OriginID": "",
+        "Type": "count",
+        "Timestamp": 1667560641226420925,
+        "Value": 10000
+      }
+    ]
+  }

--- a/pkg/otlp/metrics/testdata/datadogdata/mixed/simple_keep.json
+++ b/pkg/otlp/metrics/testdata/datadogdata/mixed/simple_keep.json
@@ -1,0 +1,197 @@
+{
+  "Sketches": [
+    {
+      "Name": "double.histogram",
+      "Tags": [
+        "custom_attribute:custom_value",
+        "deployment.environment:dev"
+      ],
+      "Host": "res-hostname",
+      "OriginID": "",
+      "Timestamp": 1667560641226420924,
+      "Summary": {
+        "Min": 0,
+        "Max": 0,
+        "Sum": 1.618033988749895,
+        "Avg": 0.08090169943749474,
+        "Cnt": 20
+      },
+      "Keys": [
+        0
+      ],
+      "Counts": [
+        20
+      ]
+    }
+  ],
+  "TimeSeries": [
+    {
+      "Name": "int.gauge",
+      "Tags": [
+        "custom_attribute:custom_value",
+        "deployment.environment:dev"
+      ],
+      "Host": "res-hostname",
+      "OriginID": "",
+      "Type": "gauge",
+      "Timestamp": 1667560641226420924,
+      "Value": 1
+    },
+    {
+      "Name": "double.gauge",
+      "Tags": [
+        "custom_attribute:custom_value",
+        "deployment.environment:dev"
+      ],
+      "Host": "res-hostname",
+      "OriginID": "",
+      "Type": "gauge",
+      "Timestamp": 1667560641226420924,
+      "Value": 3.141592653589793
+    },
+    {
+      "Name": "int.delta.sum",
+      "Tags": [
+        "custom_attribute:custom_value",
+        "deployment.environment:dev"
+      ],
+      "Host": "res-hostname",
+      "OriginID": "",
+      "Type": "count",
+      "Timestamp": 1667560641226420924,
+      "Value": 2
+    },
+    {
+      "Name": "double.delta.sum",
+      "Tags": [
+        "custom_attribute:custom_value",
+        "deployment.environment:dev"
+      ],
+      "Host": "res-hostname",
+      "OriginID": "",
+      "Type": "count",
+      "Timestamp": 1667560641226420924,
+      "Value": 2.718281828459045
+    },
+    {
+      "Name": "int.delta.monotonic.sum",
+      "Tags": [
+        "custom_attribute:custom_value",
+        "deployment.environment:dev"
+      ],
+      "Host": "res-hostname",
+      "OriginID": "",
+      "Type": "count",
+      "Timestamp": 1667560641226420924,
+      "Value": 2
+    },
+    {
+      "Name": "double.delta.monotonic.sum",
+      "Tags": [
+        "custom_attribute:custom_value",
+        "deployment.environment:dev"
+      ],
+      "Host": "res-hostname",
+      "OriginID": "",
+      "Type": "count",
+      "Timestamp": 1667560641226420924,
+      "Value": 2.718281828459045
+    },
+    {
+      "Name": "int.cumulative.sum",
+      "Tags": [
+        "custom_attribute:custom_value",
+        "deployment.environment:dev"
+      ],
+      "Host": "res-hostname",
+      "OriginID": "",
+      "Type": "gauge",
+      "Timestamp": 1667560641226420924,
+      "Value": 4
+    },
+    {
+      "Name": "double.cumulative.sum",
+      "Tags": [
+        "custom_attribute:custom_value",
+        "deployment.environment:dev"
+      ],
+      "Host": "res-hostname",
+      "OriginID": "",
+      "Type": "gauge",
+      "Timestamp": 1667560641226420924,
+      "Value": 4
+    },
+    {
+      "Name": "int.cumulative.monotonic.sum",
+      "Tags": [
+        "custom_attribute:custom_value",
+        "deployment.environment:dev"
+      ],
+      "Host": "res-hostname",
+      "OriginID": "",
+      "Type": "count",
+      "Timestamp": 1667560641226420924,
+      "Value": 4
+    },
+    {
+      "Name": "int.cumulative.monotonic.sum",
+      "Tags": [
+        "custom_attribute:custom_value",
+        "deployment.environment:dev"
+      ],
+      "Host": "res-hostname",
+      "OriginID": "",
+      "Type": "count",
+      "Timestamp": 1667560641226420925,
+      "Value": 3
+    },
+    {
+      "Name": "double.cumulative.monotonic.sum",
+      "Tags": [
+        "custom_attribute:custom_value",
+        "deployment.environment:dev"
+      ],
+      "Host": "res-hostname",
+      "OriginID": "",
+      "Type": "count",
+      "Timestamp": 1667560641226420924,
+      "Value": 4
+    },
+    {
+      "Name": "double.cumulative.monotonic.sum",
+      "Tags": [
+        "custom_attribute:custom_value",
+        "deployment.environment:dev"
+      ],
+      "Host": "res-hostname",
+      "OriginID": "",
+      "Type": "count",
+      "Timestamp": 1667560641226420925,
+      "Value": 3
+    },
+    {
+      "Name": "summary.count",
+      "Tags": [
+        "custom_attribute:custom_value",
+        "deployment.environment:dev"
+      ],
+      "Host": "res-hostname",
+      "OriginID": "",
+      "Type": "count",
+      "Timestamp": 1667560641226420925,
+      "Value": 100
+    },
+    {
+      "Name": "summary.sum",
+      "Tags": [
+        "custom_attribute:custom_value",
+        "deployment.environment:dev"
+      ],
+      "Host": "res-hostname",
+      "OriginID": "",
+      "Type": "count",
+      "Timestamp": 1667560641226420925,
+      "Value": 10000
+    }
+  ]
+}


### PR DESCRIPTION
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

- [pkg/otlp/metrics] Use NumberMode internally instead of 'SendMonotonic'
- [pkg/otlp/metrics] Add initial value mode to set what to do with the initial value of a cumulative monotonic sum when under the 'cumulative_to_delta' mode. Possible values are the same as in open-telemetry/opentelemetry-collector-contrib/pull/21905.


### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Relates to #100
