### PR TITLE
Add support for OTel Python runtime metrics

### DIFF
--- a/.chloggen/stanley.liu_python-runtime-metrics.yaml
+++ b/.chloggen/stanley.liu_python-runtime-metrics.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component (e.g. pkg/quantile)
+component: pkg/otlp/metrics
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: The OTLP metrics converter now maps OpenTelemetry Python runtime metrics to their Datadog counterparts.
+
+# The PR related to this change
+issues: [114]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/pkg/otlp/metrics/runtime_metric_mappings.go
+++ b/pkg/otlp/metrics/runtime_metric_mappings.go
@@ -6,7 +6,6 @@ var runtimeMetricPrefixLanguageMap = map[string]string{
 	"process.runtime.dotnet":  "dotnet",
 	"process.runtime.jvm":     "jvm",
 	"process.runtime.cpython": "python",
-	"runtime.cpython":         "python",
 }
 
 // runtimeMetricMapping defines the fields needed to map OTel runtime metrics to their equivalent
@@ -227,45 +226,6 @@ var javaRuntimeMetricsMappings = runtimeMetricMappingList{
 }
 
 var pythonRuntimeMetricsMappings = runtimeMetricMappingList{
-	"runtime.cpython.cpu_time": {{
-		mappedName: "runtime.python.cpu.time.sys",
-		attributes: []runtimeMetricAttribute{{
-			key:    "type",
-			values: []string{"system"},
-		}},
-	}, {
-		mappedName: "runtime.python.cpu.time.user",
-		attributes: []runtimeMetricAttribute{{
-			key:    "type",
-			values: []string{"user"},
-		}},
-	}},
-	"runtime.cpython.gc_count": {{
-		mappedName: "runtime.python.gc.count.gen0",
-		attributes: []runtimeMetricAttribute{{
-			key:    "count",
-			values: []string{"0"},
-		}},
-	}, {
-		mappedName: "runtime.python.gc.count.gen1",
-		attributes: []runtimeMetricAttribute{{
-			key:    "count",
-			values: []string{"1"},
-		}},
-	}, {
-		mappedName: "runtime.python.gc.count.gen2",
-		attributes: []runtimeMetricAttribute{{
-			key:    "count",
-			values: []string{"2"},
-		}},
-	}},
-	"runtime.cpython.memory": {{
-		mappedName: "runtime.python.mem.rss",
-		attributes: []runtimeMetricAttribute{{
-			key:    "type",
-			values: []string{"rss"},
-		}},
-	}},
 	"process.runtime.cpython.cpu_time": {{
 		mappedName: "runtime.python.cpu.time.sys",
 		attributes: []runtimeMetricAttribute{{

--- a/pkg/otlp/metrics/runtime_metric_mappings.go
+++ b/pkg/otlp/metrics/runtime_metric_mappings.go
@@ -2,10 +2,11 @@ package metrics
 
 // runtimeMetricPrefixLanguageMap defines the runtime metric prefixes and which languages they map to
 var runtimeMetricPrefixLanguageMap = map[string]string{
-	"process.runtime.go":     "go",
-	"process.runtime.dotnet": "dotnet",
-	"process.runtime.jvm":    "jvm",
-	"process.runtime.python": "python",
+	"process.runtime.go":      "go",
+	"process.runtime.dotnet":  "dotnet",
+	"process.runtime.jvm":     "jvm",
+	"process.runtime.cpython": "python",
+	"runtime.cpython":         "python",
 }
 
 // runtimeMetricMapping defines the fields needed to map OTel runtime metrics to their equivalent

--- a/pkg/otlp/metrics/runtime_metric_mappings.go
+++ b/pkg/otlp/metrics/runtime_metric_mappings.go
@@ -5,6 +5,7 @@ var runtimeMetricPrefixLanguageMap = map[string]string{
 	"process.runtime.go":     "go",
 	"process.runtime.dotnet": "dotnet",
 	"process.runtime.jvm":    "jvm",
+	"process.runtime.python": "python",
 }
 
 // runtimeMetricMapping defines the fields needed to map OTel runtime metrics to their equivalent
@@ -224,6 +225,87 @@ var javaRuntimeMetricsMappings = runtimeMetricMappingList{
 	}},
 }
 
+var pythonRuntimeMetricsMappings = runtimeMetricMappingList{
+	"runtime.cpython.cpu_time": {{
+		mappedName: "runtime.python.cpu.time.sys",
+		attributes: []runtimeMetricAttribute{{
+			key:    "type",
+			values: []string{"system"},
+		}},
+	}, {
+		mappedName: "runtime.python.cpu.time.user",
+		attributes: []runtimeMetricAttribute{{
+			key:    "type",
+			values: []string{"user"},
+		}},
+	}},
+	"runtime.cpython.gc_count": {{
+		mappedName: "runtime.python.gc.count.gen0",
+		attributes: []runtimeMetricAttribute{{
+			key:    "count",
+			values: []string{"0"},
+		}},
+	}, {
+		mappedName: "runtime.python.gc.count.gen1",
+		attributes: []runtimeMetricAttribute{{
+			key:    "count",
+			values: []string{"1"},
+		}},
+	}, {
+		mappedName: "runtime.python.gc.count.gen2",
+		attributes: []runtimeMetricAttribute{{
+			key:    "count",
+			values: []string{"2"},
+		}},
+	}},
+	"runtime.cpython.memory": {{
+		mappedName: "runtime.python.mem.rss",
+		attributes: []runtimeMetricAttribute{{
+			key:    "type",
+			values: []string{"rss"},
+		}},
+	}},
+	"process.runtime.cpython.cpu_time": {{
+		mappedName: "runtime.python.cpu.time.sys",
+		attributes: []runtimeMetricAttribute{{
+			key:    "type",
+			values: []string{"system"},
+		}},
+	}, {
+		mappedName: "runtime.python.cpu.time.user",
+		attributes: []runtimeMetricAttribute{{
+			key:    "type",
+			values: []string{"user"},
+		}},
+	}},
+	"process.runtime.cpython.gc_count": {{
+		mappedName: "runtime.python.gc.count.gen0",
+		attributes: []runtimeMetricAttribute{{
+			key:    "count",
+			values: []string{"0"},
+		}},
+	}, {
+		mappedName: "runtime.python.gc.count.gen1",
+		attributes: []runtimeMetricAttribute{{
+			key:    "count",
+			values: []string{"1"},
+		}},
+	}, {
+		mappedName: "runtime.python.gc.count.gen2",
+		attributes: []runtimeMetricAttribute{{
+			key:    "count",
+			values: []string{"2"},
+		}},
+	}},
+	"process.runtime.cpython.memory": {{
+		mappedName: "runtime.python.mem.rss",
+		attributes: []runtimeMetricAttribute{{
+			key:    "type",
+			values: []string{"rss"},
+		}},
+	}},
+}
+
 func getRuntimeMetricsMappings() runtimeMetricMappingList {
 	res := runtimeMetricMappingList{}
 	for k, v := range goRuntimeMetricsMappings {
@@ -233,6 +315,9 @@ func getRuntimeMetricsMappings() runtimeMetricMappingList {
 		res[k] = v
 	}
 	for k, v := range javaRuntimeMetricsMappings {
+		res[k] = v
+	}
+	for k, v := range pythonRuntimeMetricsMappings {
 		res[k] = v
 	}
 	return res


### PR DESCRIPTION
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Adds mappings and prefixes for OTel Python runtime metrics. The v2 DD Python names are still undecided, so the DD prefixes in the mappings will change before merging.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

