### PR TITLE
Fix depguard in golangci

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -36,6 +36,20 @@ linters-settings:
     include-go-root: true
     packages-with-error-message:
       - sync/atomic: "Use go.uber.org/atomic instead"
+    rules:
+      main:
+        files:
+          - $all
+        allow:
+          - github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes
+          - github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes/source
+          - github.com/DataDog/opentelemetry-mapping-go/pkg/inframetadata/gohai
+          - github.com/DataDog/opentelemetry-mapping-go/pkg/inframetadata/payload
+          - github.com/DataDog/opentelemetry-mapping-go/pkg/inframetadata/internal/hostmap
+          - github.com/DataDog/opentelemetry-mapping-go/pkg/inframetadata/internal/testutils
+          - github.com/stretchr/testify/assert
+          - github.com/stretchr/testify/require
+          
   staticcheck:
     go: "1.19"
     checks: ["all",

--- a/pkg/inframetadata/go.mod
+++ b/pkg/inframetadata/go.mod
@@ -27,3 +27,13 @@ require (
 )
 
 replace github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes => ../otlp/attributes
+
+replace github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes/source => ../otlp/attributes/source
+
+replace github.com/DataDog/opentelemetry-mapping-go/pkg/inframetadata/gohai => ./gohai
+
+replace github.com/DataDog/opentelemetry-mapping-go/pkg/inframetadata/payload => ./payload
+
+replace github.com/DataDog/opentelemetry-mapping-go/pkg/inframetadata/internal/hostmap => ./internal/hostmap
+
+replace github.com/DataDog/opentelemetry-mapping-go/pkg/inframetadata/internal/testutils => ./internal/testutils

--- a/pkg/inframetadata/go.mod
+++ b/pkg/inframetadata/go.mod
@@ -27,13 +27,3 @@ require (
 )
 
 replace github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes => ../otlp/attributes
-
-replace github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes/source => ../otlp/attributes/source
-
-replace github.com/DataDog/opentelemetry-mapping-go/pkg/inframetadata/gohai => ./gohai
-
-replace github.com/DataDog/opentelemetry-mapping-go/pkg/inframetadata/payload => ./payload
-
-replace github.com/DataDog/opentelemetry-mapping-go/pkg/inframetadata/internal/hostmap => ./internal/hostmap
-
-replace github.com/DataDog/opentelemetry-mapping-go/pkg/inframetadata/internal/testutils => ./internal/testutils


### PR DESCRIPTION
### What does this PR do?

Fix the depguard failures in https://github.com/DataDog/opentelemetry-mapping-go/actions/runs/5442944976/jobs/9898864233?pr=115.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

