### PR TITLE
[.github] Increase golangci lint timeout

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -95,7 +95,7 @@ jobs:
       - name: Check licenses file
         run: make gen-licenses && git diff -s --exit-code || (echo "make gen-licenses needed"; exit 1)
       - name: Check golangci-lint
-        run: make lint
+        run: make lint OPTS="--timeout 2m"
 
   breaking-changes:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### What does this PR do?

Increase golangci lint timeout to 2m. Default is 1m.

### Motivation

Fix CI flakiness, e.g. https://github.com/DataDog/opentelemetry-mapping-go/actions/runs/5646270380/job/15293842397

