### PR TITLE
[pkg/otlp/logs] Remove otel_source tag from log translator

### DIFF
--- a/pkg/otlp/logs/logs_translator.go
+++ b/pkg/otlp/logs/logs_translator.go
@@ -60,9 +60,6 @@ const (
 	logLevelFatal = "fatal"
 )
 
-// otelTag specifies a tag to be added to all logs sent from the Datadog exporter
-const otelTag = "otel_source:datadog_exporter"
-
 // Transform converts the log record in lr, which came in with the resource in res to a Datadog log item.
 // the variable specifies if the log body should be sent as an attribute or as a plain message.
 func Transform(lr plog.LogRecord, res pcommon.Resource, logger *zap.Logger) datadogV2.HTTPLogItem {
@@ -113,7 +110,7 @@ func Transform(lr plog.LogRecord, res pcommon.Resource, logger *zap.Logger) data
 				l.AdditionalProperties[otelSpanID] = v.AsString()
 			}
 		case "ddtags":
-			var tags = append(attributes.TagsFromAttributes(res.Attributes()), v.AsString(), otelTag)
+			var tags = append(attributes.TagsFromAttributes(res.Attributes()), v.AsString())
 			tagStr := strings.Join(tags, ",")
 			l.Ddtags = datadog.PtrString(tagStr)
 		default:
@@ -157,7 +154,7 @@ func Transform(lr plog.LogRecord, res pcommon.Resource, logger *zap.Logger) data
 	}
 
 	if !l.HasDdtags() {
-		var tags = append(attributes.TagsFromAttributes(res.Attributes()), otelTag)
+		var tags = attributes.TagsFromAttributes(res.Attributes())
 		tagStr := strings.Join(tags, ",")
 		l.Ddtags = datadog.PtrString(tagStr)
 	}

--- a/pkg/otlp/logs/logs_translator_test.go
+++ b/pkg/otlp/logs/logs_translator_test.go
@@ -57,7 +57,7 @@ func TestTransform(t *testing.T) {
 				res: pcommon.NewResource(),
 			},
 			want: datadogV2.HTTPLogItem{
-				Ddtags:  datadog.PtrString("otel_source:datadog_exporter"),
+				Ddtags:  datadog.PtrString(""),
 				Message: *datadog.PtrString(""),
 				AdditionalProperties: map[string]string{
 					"app":              "test",
@@ -83,7 +83,7 @@ func TestTransform(t *testing.T) {
 				}(),
 			},
 			want: datadogV2.HTTPLogItem{
-				Ddtags:  datadog.PtrString("service:otlp_col,otel_source:datadog_exporter"),
+				Ddtags:  datadog.PtrString("service:otlp_col"),
 				Message: *datadog.PtrString(""),
 				Service: datadog.PtrString("otlp_col"),
 				AdditionalProperties: map[string]string{
@@ -111,7 +111,7 @@ func TestTransform(t *testing.T) {
 				}(),
 			},
 			want: datadogV2.HTTPLogItem{
-				Ddtags:  datadog.PtrString("service:otlp_col,foo:bar,otel_source:datadog_exporter"),
+				Ddtags:  datadog.PtrString("service:otlp_col,foo:bar"),
 				Message: *datadog.PtrString(""),
 				Service: datadog.PtrString("otlp_col"),
 				AdditionalProperties: map[string]string{
@@ -138,7 +138,7 @@ func TestTransform(t *testing.T) {
 				}(),
 			},
 			want: datadogV2.HTTPLogItem{
-				Ddtags:  datadog.PtrString("otel_source:datadog_exporter"),
+				Ddtags:  datadog.PtrString(""),
 				Message: *datadog.PtrString(""),
 				Service: datadog.PtrString("otlp_col"),
 				AdditionalProperties: map[string]string{
@@ -167,7 +167,7 @@ func TestTransform(t *testing.T) {
 				}(),
 			},
 			want: datadogV2.HTTPLogItem{
-				Ddtags:  datadog.PtrString("otel_source:datadog_exporter"),
+				Ddtags:  datadog.PtrString(""),
 				Message: *datadog.PtrString(""),
 				Service: datadog.PtrString("otlp_col"),
 				AdditionalProperties: map[string]string{
@@ -200,7 +200,7 @@ func TestTransform(t *testing.T) {
 				}(),
 			},
 			want: datadogV2.HTTPLogItem{
-				Ddtags:  datadog.PtrString("otel_source:datadog_exporter"),
+				Ddtags:  datadog.PtrString(""),
 				Message: *datadog.PtrString(""),
 				Service: datadog.PtrString("otlp_col"),
 				AdditionalProperties: map[string]string{
@@ -233,7 +233,7 @@ func TestTransform(t *testing.T) {
 				}(),
 			},
 			want: datadogV2.HTTPLogItem{
-				Ddtags:  datadog.PtrString("otel_source:datadog_exporter"),
+				Ddtags:  datadog.PtrString(""),
 				Message: *datadog.PtrString(""),
 				Service: datadog.PtrString("otlp_col"),
 				AdditionalProperties: map[string]string{
@@ -266,7 +266,7 @@ func TestTransform(t *testing.T) {
 				}(),
 			},
 			want: datadogV2.HTTPLogItem{
-				Ddtags:  datadog.PtrString("otel_source:datadog_exporter"),
+				Ddtags:  datadog.PtrString(""),
 				Message: *datadog.PtrString(""),
 				Service: datadog.PtrString("otlp_col"),
 				AdditionalProperties: map[string]string{
@@ -301,7 +301,7 @@ func TestTransform(t *testing.T) {
 				}(),
 			},
 			want: datadogV2.HTTPLogItem{
-				Ddtags:  datadog.PtrString("otel_source:datadog_exporter"),
+				Ddtags:  datadog.PtrString(""),
 				Message: *datadog.PtrString(""),
 				Service: datadog.PtrString("otlp_col"),
 				AdditionalProperties: map[string]string{
@@ -336,7 +336,7 @@ func TestTransform(t *testing.T) {
 				}(),
 			},
 			want: datadogV2.HTTPLogItem{
-				Ddtags:  datadog.PtrString("otel_source:datadog_exporter"),
+				Ddtags:  datadog.PtrString(""),
 				Message: *datadog.PtrString(""),
 				Service: datadog.PtrString("otlp_col"),
 				AdditionalProperties: map[string]string{


### PR DESCRIPTION
### What does this PR do?

Do not append `otel_source` tag to DDTags. Removed so that datadog-exporter and datadog-agent can each append their own `otel_source` tags.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

