### PR TITLE
[chore] Shrink `Agent` struct from 104 bytes to 56

### DIFF
--- a/pkg/quantile/agent.go
+++ b/pkg/quantile/agent.go
@@ -14,9 +14,9 @@ var agentConfig = Default()
 // An Agent sketch is an insert optimized version of the sketch for use in the
 // datadog-agent.
 type Agent struct {
-	Sketch   Sketch
 	Buf      []Key
 	CountBuf []KeyCount
+	Sketch   Sketch
 }
 
 // IsEmpty returns true if the sketch is empty


### PR DESCRIPTION
### What does this PR do?

This commit reorders the fields in the Agent struct to require less padding in that type, shrinking it by ~1/2. No change in behavior is intended.

### Motivation

This was discovered while investigating high memory use in the Agent under some circumstances, see SMP-664 and AML-825.
