### PR TITLE
Add resource attributes to log

### DIFF
--- a/.chloggen/otel_744_add_resource_attrs_to_log.yaml
+++ b/.chloggen/otel_744_add_resource_attrs_to_log.yaml
@@ -5,7 +5,7 @@ change_type: bug_fix
 component: pkg/otlp
 
 # A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
-note: Add resource attributes to AdditionalProperties field of log
+note: Populate OTLP resource attributes in Datadog logs
 
 # The PR related to this change
 issues: [138]

--- a/.chloggen/otel_744_add_resource_attrs_to_log.yaml
+++ b/.chloggen/otel_744_add_resource_attrs_to_log.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component (e.g. pkg/quantile)
+component: pkg/otlp
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add resource attributes to AdditionalProperties field of log
+
+# The PR related to this change
+issues: [138]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/pkg/otlp/logs/logs_translator.go
+++ b/pkg/otlp/logs/logs_translator.go
@@ -119,6 +119,8 @@ func Transform(lr plog.LogRecord, res pcommon.Resource, logger *zap.Logger) data
 		return true
 	})
 	res.Attributes().Range(func(k string, v pcommon.Value) bool {
+		// "hostname" and "service" are reserved keywords in HTTPLogItem
+		// Prefix the keys so they aren't overwritten when marshalling
 		if k == "hostname" || k == "service" {
 			l.AdditionalProperties["otel."+k] = v.AsString()
 		} else {

--- a/pkg/otlp/logs/logs_translator.go
+++ b/pkg/otlp/logs/logs_translator.go
@@ -118,6 +118,14 @@ func Transform(lr plog.LogRecord, res pcommon.Resource, logger *zap.Logger) data
 		}
 		return true
 	})
+	res.Attributes().Range(func(k string, v pcommon.Value) bool {
+		if k == "hostname" || k == "service" {
+			l.AdditionalProperties["otel."+k] = v.AsString()
+		} else {
+			l.AdditionalProperties[k] = v.AsString()
+		}
+		return true
+	})
 	if traceID := lr.TraceID(); !traceID.IsEmpty() {
 		l.AdditionalProperties[ddTraceID] = strconv.FormatUint(traceIDToUint64(traceID), 10)
 		l.AdditionalProperties[otelTraceID] = hex.EncodeToString(traceID[:])

--- a/pkg/otlp/logs/logs_translator_test.go
+++ b/pkg/otlp/logs/logs_translator_test.go
@@ -90,6 +90,7 @@ func TestTransform(t *testing.T) {
 					"app":              "test",
 					"status":           "debug",
 					otelSeverityNumber: "5",
+					"service.name":     "otlp_col",
 				},
 			},
 		},
@@ -118,6 +119,7 @@ func TestTransform(t *testing.T) {
 					"app":              "test",
 					"status":           "debug",
 					otelSeverityNumber: "5",
+					"service.name":     "otlp_col",
 				},
 			},
 		},
@@ -348,6 +350,63 @@ func TestTransform(t *testing.T) {
 					ddSpanID:       fmt.Sprintf("%d", ddSp),
 					ddTraceID:      fmt.Sprintf("%d", ddTr),
 					"service.name": "otlp_col",
+				},
+			},
+		},
+		{
+			name: "resource attributes in additional properties",
+			args: args{
+				lr: func() plog.LogRecord {
+					l := plog.NewLogRecord()
+					l.Attributes().PutStr("app", "test")
+					l.SetSeverityNumber(5)
+					return l
+				}(),
+				res: func() pcommon.Resource {
+					r := pcommon.NewResource()
+					r.Attributes().PutStr(conventions.AttributeServiceName, "otlp_col")
+					r.Attributes().PutStr("key", "val")
+					return r
+				}(),
+			},
+			want: datadogV2.HTTPLogItem{
+				Ddtags:  datadog.PtrString("service:otlp_col"),
+				Message: *datadog.PtrString(""),
+				Service: datadog.PtrString("otlp_col"),
+				AdditionalProperties: map[string]string{
+					"app":              "test",
+					"status":           "debug",
+					otelSeverityNumber: "5",
+					"key":              "val",
+					"service.name":     "otlp_col",
+				},
+			},
+		},
+		{
+			name: "resource attributes in additional properties",
+			args: args{
+				lr: func() plog.LogRecord {
+					l := plog.NewLogRecord()
+					l.Attributes().PutStr("app", "test")
+					l.SetSeverityNumber(5)
+					return l
+				}(),
+				res: func() pcommon.Resource {
+					r := pcommon.NewResource()
+					r.Attributes().PutStr("hostname", "example_host")
+					r.Attributes().PutStr("service", "otlp_col")
+					return r
+				}(),
+			},
+			want: datadogV2.HTTPLogItem{
+				Ddtags:  datadog.PtrString(""),
+				Message: *datadog.PtrString(""),
+				AdditionalProperties: map[string]string{
+					"app":              "test",
+					"status":           "debug",
+					otelSeverityNumber: "5",
+					"otel.service":     "otlp_col",
+					"otel.hostname":    "example_host",
 				},
 			},
 		},

--- a/pkg/otlp/logs/logs_translator_test.go
+++ b/pkg/otlp/logs/logs_translator_test.go
@@ -383,7 +383,7 @@ func TestTransform(t *testing.T) {
 			},
 		},
 		{
-			name: "resource attributes in additional properties",
+			name: "DD hostname and service are not overridden by resource attributes",
 			args: args{
 				lr: func() plog.LogRecord {
 					l := plog.NewLogRecord()


### PR DESCRIPTION
### What does this PR do?

Instead of discarding all resource attributes other than hostname and service, populate "AdditionalProperties" of logs. To avoid overwriting those attributes when marshalling JSON (if they're populated elsewhere), prefix those attributes with "`otel.`"

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

https://datadoghq.atlassian.net/browse/OTEL-744
