### PR TITLE
pkg/otlp/metrics: fix otel.* namespaced metrics

### DIFF
--- a/.chloggen/gbbr_fix-otel-namespace.yaml
+++ b/.chloggen/gbbr_fix-otel-namespace.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component (e.g. pkg/quantile)
+component: pkg/otlp
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: System (and process.*) metrics were remapped with otel.*, overwriting the original metric and losing it. This change fixes that, keeping the original metric.
+
+# The PR related to this change
+issues: [141]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/pkg/otlp/metrics/metrics_remapping.go
+++ b/pkg/otlp/metrics/metrics_remapping.go
@@ -70,7 +70,9 @@ func remapSystemMetrics(all pmetric.MetricSlice, m pmetric.Metric) {
 		copyMetric(all, m, "system.disk.in_use", 1)
 	}
 	// process.* and system.* metrics need to be prepended with the otel.* namespace
-	m.SetName("otel." + m.Name())
+	newm := all.AppendEmpty()
+	m.CopyTo(newm)
+	newm.SetName("otel." + m.Name())
 }
 
 // remapContainerMetrics extracts system metrics from m and appends them to all.


### PR DESCRIPTION
This change fixes a problem where sytem.* and process.* metrics were correctly namespaced with otel.*, but the original metric was not kept.