### PR TITLE
Fix mapping for `jvm.loaded_classes`

### DIFF
--- a/.chloggen/stanley.liu_update-jvm-loaded-classes.yaml
+++ b/.chloggen/stanley.liu_update-jvm-loaded-classes.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component (e.g. pkg/quantile)
+component: pkg/otlp/metrics
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Changes mapping for jvm.loaded_classes from process.runtime.jvm.classes.loaded to process.runtime.jvm.classes.current_loaded
+
+# The PR related to this change
+issues: [143]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/pkg/otlp/metrics/metrics_translator_test.go
+++ b/pkg/otlp/metrics/metrics_translator_test.go
@@ -620,7 +620,7 @@ func TestMapRuntimeMetricsMultipleLanguageTags(t *testing.T) {
 	}
 	assert.ElementsMatch(t, []string{"go", "dotnet"}, rmt.Languages)
 
-	exampleDims = newDims("process.runtime.jvm.classes.loaded")
+	exampleDims = newDims("process.runtime.jvm.classes.current_loaded")
 	md4 := createTestIntCumulativeMonotonicMetrics(false)
 	md3.ResourceMetrics().MoveAndAppendTo(md4.ResourceMetrics())
 	rmt, err = tr.MapMetrics(ctx, md4, consumer)

--- a/pkg/otlp/metrics/runtime_metric_mappings.go
+++ b/pkg/otlp/metrics/runtime_metric_mappings.go
@@ -91,7 +91,7 @@ var dotnetRuntimeMetricsMappings = runtimeMetricMappingList{
 
 var javaRuntimeMetricsMappings = runtimeMetricMappingList{
 	"process.runtime.jvm.threads.count":          {{mappedName: "jvm.thread_count"}},
-	"process.runtime.jvm.classes.loaded":         {{mappedName: "jvm.loaded_classes"}},
+	"process.runtime.jvm.classes.current_loaded": {{mappedName: "jvm.loaded_classes"}},
 	"process.runtime.jvm.system.cpu.utilization": {{mappedName: "jvm.cpu_load.system"}},
 	"process.runtime.jvm.cpu.utilization":        {{mappedName: "jvm.cpu_load.process"}},
 	"process.runtime.jvm.gc.duration":            {{mappedName: "jvm.gc.parnew.time"}},


### PR DESCRIPTION
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Changes mapping for `jvm.loaded_classes` from `process.runtime.jvm.classes.loaded` to `process.runtime.jvm.classes.current_loaded`

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->
#124 

