### PR TITLE
[pkg/inframetadata] Send payload on changes, add ConsumeHostMetadata

### DIFF
--- a/.chloggen/mx-psi_hostmetadata-on-first-sight.yaml
+++ b/.chloggen/mx-psi_hostmetadata-on-first-sight.yaml
@@ -1,0 +1,17 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component (e.g. pkg/quantile)
+component: pkg/inframetadata
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Host metadata is now reported the first time new information becomes available for a host.
+
+# The PR related to this change
+issues: [150]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:
+  

--- a/pkg/inframetadata/internal/hostmap/hostmap.go
+++ b/pkg/inframetadata/internal/hostmap/hostmap.go
@@ -86,9 +86,18 @@ func ec2Hostname(m pcommon.Map) (string, bool, error) {
 	return strField(m, conventions.AttributeHostName)
 }
 
+// Set a hardcoded host metadata payload.
+func (m *HostMap) Set(md payload.HostMetadata) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.hosts[md.Meta.Hostname] = md
+	return nil
+}
+
 // Update the information about a given host by providing a resource.
 // The function reports:
 //   - Whether the information about the `host` has changed
+//   - The host metadata payload stored
 //   - Any non-fatal errors that may have occurred during the update
 //
 // Non-fatal errors are local to the specific field where they happened
@@ -98,8 +107,8 @@ func ec2Hostname(m pcommon.Map) (string, bool, error) {
 //
 // The order in which resource attributes are read does not affect the final
 // host metadata payload, even if non-fatal errors are raised during execution.
-func (m *HostMap) Update(host string, res pcommon.Resource) (changed bool, err error) {
-	md := payload.HostMetadata{
+func (m *HostMap) Update(host string, res pcommon.Resource) (changed bool, md payload.HostMetadata, err error) {
+	md = payload.HostMetadata{
 		Flavor:  "otelcol-contrib",
 		Meta:    &payload.Meta{},
 		Tags:    &payload.HostTags{},

--- a/pkg/inframetadata/internal/hostmap/hostmap_test.go
+++ b/pkg/inframetadata/internal/hostmap/hostmap_test.go
@@ -96,7 +96,7 @@ func TestUpdate(t *testing.T) {
 
 	hostMap := New()
 	for _, info := range hostInfo {
-		changed, err := hostMap.Update(info.hostname, testutils.NewResourceFromMap(t, info.attributes))
+		changed, _, err := hostMap.Update(info.hostname, testutils.NewResourceFromMap(t, info.attributes))
 		assert.Equal(t, info.expectedChanged, changed)
 		if len(info.expectedErrs) > 0 {
 			var errStrings []string


### PR DESCRIPTION
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

- Add `Set` method to `Reporter`
- Push host metadata the first time a host is seen or its metadata changes.

