### PR TITLE
Pool the overflow list in `sparseStore.trimLeft`

### DIFF
--- a/pkg/quantile/pool.go
+++ b/pkg/quantile/pool.go
@@ -10,8 +10,9 @@ import (
 )
 
 const (
-	defaultBinListSize = 2 * defaultBinLimit
-	defaultKeyListSize = 256
+	defaultBinListSize      = 2 * defaultBinLimit
+	defaultKeyListSize      = 256
+	defaultOverflowListSize = 16
 )
 
 var (
@@ -26,6 +27,13 @@ var (
 	keyListPool = sync.Pool{
 		New: func() interface{} {
 			a := make([]Key, 0, defaultKeyListSize)
+			return &a
+		},
+	}
+
+	overflowListPool = sync.Pool{
+		New: func() interface{} {
+			a := make([]bin, 0, defaultOverflowListSize)
 			return &a
 		},
 	}
@@ -47,4 +55,13 @@ func getKeyList() []Key {
 
 func putKeyList(a []Key) {
 	keyListPool.Put(&a)
+}
+
+func getOverflowList() []bin {
+	a := *(overflowListPool.Get().(*[]bin))
+	return a[:0]
+}
+
+func putOverflowList(a []bin) {
+	overflowListPool.Put(&a)
 }

--- a/pkg/quantile/store.go
+++ b/pkg/quantile/store.go
@@ -70,7 +70,7 @@ func trimLeft(a []bin, maxBucketCap int) []bin {
 		nRemove = len(a) - maxBucketCap
 
 		missing  int
-		overflow []bin
+		overflow = getOverflowList()
 	)
 
 	// TODO|PROD: Benchmark a better overflow scheme.
@@ -100,10 +100,13 @@ func trimLeft(a []bin, maxBucketCap int) []bin {
 		overflow = appendSafe(overflow, a[nRemove].k, missing)
 	}
 
-	copy(a, overflow)
-	copy(a[len(overflow):], a[nRemove:])
+	overflowLen := len(overflow)
 
-	return a[:maxBucketCap+len(overflow)]
+	copy(a, overflow)
+	copy(a[overflowLen:], a[nRemove:])
+	putOverflowList(overflow)
+
+	return a[:maxBucketCap+overflowLen]
 }
 
 func (s *sparseStore) merge(c *Config, o *sparseStore) {


### PR DESCRIPTION
### What does this PR do?

Reduce allocations in `sparseStore.trimLeft` by pooling the overflow list. This code was identified as a hotspot as part of some agent performance work that I'm doing. (There's a writeup in a notebook [here](https://app.datadoghq.com/notebook/6366141/an-agent-performance-journey-dogstatsd).)

### Motivation

This improves agent's performance in the `uds_dogstatsd_to_api` SMP experiment by around 40%.
