### PR TITLE
WIP: Make sketches generic between 16 & 32 bits

### DIFF
--- a/pkg/otlp/metrics/consumer.go
+++ b/pkg/otlp/metrics/consumer.go
@@ -80,7 +80,7 @@ type SketchConsumer interface {
 		ctx context.Context,
 		dimensions *Dimensions,
 		timestamp uint64,
-		sketch *quantile.Sketch,
+		sketch quantile.Sketch,
 	)
 }
 

--- a/pkg/otlp/metrics/exponential_histograms_translator.go
+++ b/pkg/otlp/metrics/exponential_histograms_translator.go
@@ -156,15 +156,15 @@ func (t *Translator) mapExponentialHistogramMetrics(
 
 		if histInfo.ok {
 			// override approximate sum, count and average in sketch with exact values if available.
-			agentSketch.Basic.Cnt = int64(histInfo.count)
-			agentSketch.Basic.Sum = histInfo.sum
-			agentSketch.Basic.Avg = agentSketch.Basic.Sum / float64(agentSketch.Basic.Cnt)
+			agentSketch.Basic().Cnt = int64(histInfo.count)
+			agentSketch.Basic().Sum = histInfo.sum
+			agentSketch.Basic().Avg = agentSketch.Basic().Sum / float64(agentSketch.Basic().Cnt)
 		}
 		if delta && p.HasMin() {
-			agentSketch.Basic.Min = p.Min()
+			agentSketch.Basic().Min = p.Min()
 		}
 		if delta && p.HasMax() {
-			agentSketch.Basic.Max = p.Max()
+			agentSketch.Basic().Max = p.Max()
 		}
 
 		consumer.ConsumeSketch(ctx, pointDims, ts, agentSketch)

--- a/pkg/otlp/metrics/metrics_translator.go
+++ b/pkg/otlp/metrics/metrics_translator.go
@@ -296,36 +296,36 @@ func (t *Translator) getSketchBuckets(
 	if sketch != nil {
 		if histInfo.ok {
 			// override approximate sum, count and average in sketch with exact values if available.
-			sketch.Basic.Cnt = int64(histInfo.count)
-			sketch.Basic.Sum = histInfo.sum
-			sketch.Basic.Avg = sketch.Basic.Sum / float64(sketch.Basic.Cnt)
+			sketch.Basic().Cnt = int64(histInfo.count)
+			sketch.Basic().Sum = histInfo.sum
+			sketch.Basic().Avg = sketch.Basic().Sum / float64(sketch.Basic().Cnt)
 		}
 
 		// If there is at least one bucket with nonzero count,
 		// override min/max with bounds if they are not infinite.
 		if minBoundSet {
 			if !math.IsInf(minBound, 0) {
-				sketch.Basic.Min = minBound
+				sketch.Basic().Min = minBound
 			}
 			if !math.IsInf(maxBound, 0) {
-				sketch.Basic.Max = maxBound
+				sketch.Basic().Max = maxBound
 			}
 		}
 
 		if histInfo.hasMinFromLastTimeWindow {
 			// We know exact minimum for the last time window.
-			sketch.Basic.Min = p.Min()
+			sketch.Basic().Min = p.Min()
 		} else if p.HasMin() {
 			// Clamp minimum with the global minimum (p.Min()) to account for sketch mapping error.
-			sketch.Basic.Min = math.Max(p.Min(), sketch.Basic.Min)
+			sketch.Basic().Min = math.Max(p.Min(), sketch.Basic().Min)
 		}
 
 		if histInfo.hasMaxFromLastTimeWindow {
 			// We know exact maximum for the last time window.
-			sketch.Basic.Max = p.Max()
+			sketch.Basic().Max = p.Max()
 		} else if p.HasMax() {
 			// Clamp maximum with global maximum (p.Max()) to account for sketch mapping error.
-			sketch.Basic.Max = math.Min(p.Max(), sketch.Basic.Max)
+			sketch.Basic().Max = math.Min(p.Max(), sketch.Basic().Max)
 		}
 
 		consumer.ConsumeSketch(ctx, pointDims, ts, sketch)

--- a/pkg/otlp/metrics/metrics_translator_test.go
+++ b/pkg/otlp/metrics/metrics_translator_test.go
@@ -975,7 +975,7 @@ func (c *mockFullConsumer) ConsumeAPMStats(p *pb.ClientStatsPayload) {
 	c.apmstats = append(c.apmstats, p)
 }
 
-func (c *mockFullConsumer) ConsumeSketch(_ context.Context, dimensions *Dimensions, ts uint64, sk *quantile.Sketch) {
+func (c *mockFullConsumer) ConsumeSketch(_ context.Context, dimensions *Dimensions, ts uint64, sk quantile.Sketch) {
 	c.sketches = append(c.sketches,
 		sketch{
 			name:      dimensions.Name(),

--- a/pkg/otlp/metrics/sketches_test.go
+++ b/pkg/otlp/metrics/sketches_test.go
@@ -51,7 +51,7 @@ func (c *sketchConsumer) ConsumeSketch(
 	_ context.Context,
 	_ *Dimensions,
 	_ uint64,
-	sketch *quantile.Sketch,
+	sketch quantile.Sketch,
 ) {
 	c.sk = sketch
 }

--- a/pkg/otlp/metrics/testhelper_test.go
+++ b/pkg/otlp/metrics/testhelper_test.go
@@ -149,7 +149,7 @@ func (t *testConsumer) ConsumeSketch(
 	_ context.Context,
 	dimensions *Dimensions,
 	timestamp uint64,
-	sketch *quantile.Sketch,
+	sketch quantile.Sketch,
 ) {
 	k, n := sketch.Cols()
 	t.testMetrics.Sketches = append(t.testMetrics.Sketches,

--- a/pkg/quantile/agent.go
+++ b/pkg/quantile/agent.go
@@ -16,34 +16,36 @@ var agentConfig = Default()
 type Agent struct {
 	Buf      []Key
 	CountBuf []KeyCount
-	Sketch   Sketch
+
+	Sketch Sketch
 }
 
 // IsEmpty returns true if the sketch is empty
 func (a *Agent) IsEmpty() bool {
-	return a.Sketch.Basic.Cnt == 0 && len(a.Buf) == 0
+	return a.Sketch.Basic().Cnt == 0 && len(a.Buf) == 0
 }
 
 // Finish flushes any pending inserts and returns a deep copy of the sketch.
-func (a *Agent) Finish() *Sketch {
+func (a *Agent) Finish() Sketch {
 	a.flush()
 
 	if a.IsEmpty() {
 		return nil
 	}
 
-	return a.Sketch.Copy()
+	return a.Sketch.CopyAsSketch()
 }
 
 // flush buffered values into the sketch.
 func (a *Agent) flush() {
+	// todo: use correct sketch
 	if len(a.Buf) != 0 {
-		a.Sketch.insert(agentConfig, a.Buf)
+		a.Sketch.Insert(agentConfig, a.Buf)
 		a.Buf = nil
 	}
 
 	if len(a.CountBuf) != 0 {
-		a.Sketch.insertCounts(agentConfig, a.CountBuf)
+		a.Sketch.InsertCounts(agentConfig, a.CountBuf)
 		a.CountBuf = nil
 	}
 }
@@ -63,7 +65,7 @@ func (a *Agent) Insert(v float64, sampleRate float64) {
 	}
 
 	if sampleRate == 1 {
-		a.Sketch.Basic.Insert(v)
+		a.Sketch.Basic().Insert(v)
 		a.Buf = append(a.Buf, k)
 
 		if len(a.Buf) < agentBufCap {
@@ -72,7 +74,7 @@ func (a *Agent) Insert(v float64, sampleRate float64) {
 	} else {
 		// use truncated 1 / sampleRate as count to match histograms
 		n := 1 / sampleRate
-		a.Sketch.Basic.InsertN(v, n)
+		a.Sketch.Basic().InsertN(v, n)
 		kc := KeyCount{
 			k: k,
 			n: uint(n),
@@ -113,7 +115,7 @@ func (a *Agent) InsertInterpolate(lower float64, upper float64, count uint) {
 			if kn > whatsLeft {
 				kn = whatsLeft
 			}
-			a.Sketch.Basic.InsertN(lowerB, float64(kn))
+			a.Sketch.Basic().InsertN(lowerB, float64(kn))
 			a.CountBuf = append(a.CountBuf, KeyCount{k: keys[startIdx], n: uint(kn)})
 			whatsLeft -= kn
 			startIdx = endIdx
@@ -122,7 +124,7 @@ func (a *Agent) InsertInterpolate(lower float64, upper float64, count uint) {
 		endIdx++
 	}
 	if whatsLeft > 0 {
-		a.Sketch.Basic.InsertN(agentConfig.binLow(keys[startIdx]), float64(whatsLeft))
+		a.Sketch.Basic().InsertN(agentConfig.binLow(keys[startIdx]), float64(whatsLeft))
 		a.CountBuf = append(a.CountBuf, KeyCount{k: keys[startIdx], n: uint(whatsLeft)})
 	}
 	a.flush()

--- a/pkg/quantile/agent.go
+++ b/pkg/quantile/agent.go
@@ -38,7 +38,6 @@ func (a *Agent) Finish() Sketch {
 
 // flush buffered values into the sketch.
 func (a *Agent) flush() {
-	// todo: use correct sketch
 	if len(a.Buf) != 0 {
 		a.Sketch.Insert(agentConfig, a.Buf)
 		a.Buf = nil

--- a/pkg/quantile/agent.go
+++ b/pkg/quantile/agent.go
@@ -39,7 +39,7 @@ func (a *Agent) Finish() Sketch {
 // flush buffered values into the sketch.
 func (a *Agent) flush() {
 	if len(a.Buf) != 0 {
-		a.Sketch.Insert(agentConfig, a.Buf)
+		a.Sketch.InsertKeys(agentConfig, a.Buf)
 		a.Buf = nil
 	}
 

--- a/pkg/quantile/agent_test.go
+++ b/pkg/quantile/agent_test.go
@@ -19,8 +19,8 @@ func TestAgent(t *testing.T) {
 	type testcase struct {
 		// expected
 		// s.Basic.Cnt should equal binsum + buf
-		binsum int // expected sum(b.n) for bin in a.
-		buf    int // expected len(a.buf)
+		binsum uint64 // expected sum(b.n) for bin in a.
+		buf    uint64 // expected len(a.buf)
 
 		// action
 		ninsert int  // ninsert values are inserted before checking
@@ -47,24 +47,25 @@ func TestAgent(t *testing.T) {
 	check := func(t *testing.T, exp testcase) {
 		t.Helper()
 
-		if l := len(a.Buf); l != exp.buf {
+		if l := uint64(len(a.Buf)); l != exp.buf {
 			t.Fatalf("len(a.buf) wrong. got:%d, want:%d", l, exp.buf)
 		}
 
-		binsum := 0
-		for _, b := range a.Sketch.bins {
-			binsum += int(b.n)
+		binsum := uint64(0)
+		_, ns := a.Sketch.Cols()
+		for n := range ns {
+			binsum += uint64(n)
 		}
 
 		if got, want := binsum, exp.binsum; got != want {
 			t.Fatalf("sum(b.n) wrong. got:%d, want:%d", got, want)
 		}
 
-		if got, want := a.Sketch.count, binsum; got != want {
+		if got, want := a.Sketch.Count(), binsum; got != want {
 			t.Fatalf("s.count should match binsum. got:%d, want:%d", got, want)
 		}
 
-		if got, want := int(a.Sketch.Basic.Cnt), exp.binsum+exp.buf; got != want {
+		if got, want := uint64(a.Sketch.Basic().Cnt), exp.binsum+exp.buf; got != want {
 			t.Fatalf("Summary.Cnt should equal len(buf)+s.count. got:%d, want: %d", got, want)
 		}
 	}
@@ -139,13 +140,13 @@ func TestAgentInterpolation(t *testing.T) {
 
 		exp := ParseSketch(t, tt.exp)
 
-		if tt.count != uint(exp.Basic.Cnt) {
-			t.Errorf("Expected sketch has wrong count %v (expected %v)", exp.Basic.Cnt, tt.count)
+		if tt.count != uint(exp.Basic().Cnt) {
+			t.Errorf("Expected sketch has wrong count %v (expected %v)", exp.Basic().Cnt, tt.count)
 			t.Fail()
 		}
 
-		if tt.count != uint(a.Sketch.Basic.Cnt) {
-			t.Errorf("Actual sketch has wrong count %v (expected %v)", a.Sketch.Basic.Cnt, tt.count)
+		if tt.count != uint(a.Sketch.Basic().Cnt) {
+			t.Errorf("Actual sketch has wrong count %v (expected %v)", a.Sketch.Basic().Cnt, tt.count)
 			t.Fail()
 		}
 

--- a/pkg/quantile/bin32.go
+++ b/pkg/quantile/bin32.go
@@ -1,0 +1,86 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package quantile
+
+import (
+	"math"
+)
+
+const (
+	maxBin32Width = math.MaxUint32
+)
+
+type bin32 struct {
+	k Key
+	n uint32
+}
+
+// incrSafe performs `b.n += by` safely handling overflows. When an overflow
+// occurs, we set b.n to it's max, and return the leftover amount to increment.
+func (b *bin32) incrSafe(by int) int {
+	next := by + int(b.n)
+
+	if next > maxBin32Width {
+		b.n = maxBin32Width
+		return next - maxBin32Width
+	}
+
+	b.n = uint32(next)
+	return 0
+}
+
+// appendSafe appends 1 or more bins with the given key safely handing overflow by
+// inserting multiple buckets when needed.
+//
+//	(1) n <= maxBin32Width :  1 bin
+//	(2) n > maxBin32Width  : >1 bin
+func appendSafe32(bins []bin32, k Key, n int) []bin32 {
+	if n <= maxBin32Width {
+		return append(bins, bin32{k: k, n: uint32(n)})
+	}
+
+	// on overflow, insert multiple bins with the same key.
+	// put full bins at end
+
+	// TODO|PROD: Add validation func that sorts by key and then n (smaller bin first).
+	r := uint32(n % maxBin32Width)
+	if r != 0 {
+		bins = append(bins, bin32{k: k, n: r})
+	}
+
+	for i := 0; i < n/maxBin32Width; i++ {
+		bins = append(bins, bin32{k: k, n: maxBin32Width})
+	}
+
+	return bins
+}
+
+type binList32 []bin32
+
+func (bins binList32) nSum() uint64 {
+	var s uint64
+	s = 0
+	for _, b := range bins {
+		s += uint64(b.n)
+	}
+	return s
+}
+
+func (bins binList32) Cap() int {
+	return cap(bins)
+}
+
+func (bins binList32) Len() int {
+	return len(bins)
+}
+
+func (bins binList32) ensureLen(newLen int) binList32 {
+	for cap(bins) < newLen {
+		bins = append(bins[:cap(bins)], bin32{})
+	}
+
+	return bins[:newLen]
+}

--- a/pkg/quantile/ddsketch.go
+++ b/pkg/quantile/ddsketch.go
@@ -89,7 +89,7 @@ func convertFloatCountsToIntCounts(floatKeyCounts []floatKeyCount) []KeyCount {
 // convertDDSketchIntoSketch takes a DDSketch and moves its data to a Sketch.
 // The conversion assumes that the DDSketch has a mapping that is compatible
 // with the Sketch parameters (eg. a DDSketch returned by convertDDSketchMapping).
-func convertDDSketchIntoSketch(c *Config, inputSketch *ddsketch.DDSketch) (*Sketch, error) {
+func convertDDSketchIntoSketch(c *Config, inputSketch *ddsketch.DDSketch) (*Sketch16, error) {
 	sparseStore := sparseStore{
 		bins:  make([]bin, 0, defaultBinListSize),
 		count: 0,
@@ -158,9 +158,9 @@ func convertDDSketchIntoSketch(c *Config, inputSketch *ddsketch.DDSketch) (*Sket
 	keyCounts := convertFloatCountsToIntCounts(floatKeyCounts)
 
 	// Populate sparseStore object with the collected keyCounts
-	// insertCounts will take care of creating multiple uint16 bins for a
+	// InsertCounts will take care of creating multiple uint16 bins for a
 	// single key if the count overflows uint16
-	sparseStore.insertCounts(c, keyCounts)
+	sparseStore.InsertCounts(c, keyCounts)
 
 	// Create summary object
 	// Calculate the total count that was inserted in the Sketch
@@ -189,9 +189,9 @@ func convertDDSketchIntoSketch(c *Config, inputSketch *ddsketch.DDSketch) (*Sket
 	}
 
 	// Build the final Sketch object
-	outputSketch := &Sketch{
-		sparseStore: sparseStore,
-		Basic:       summary,
+	outputSketch := &Sketch16{
+		sparseStore:  sparseStore,
+		BasicSummary: summary,
 	}
 
 	return outputSketch, nil
@@ -201,7 +201,7 @@ func convertDDSketchIntoSketch(c *Config, inputSketch *ddsketch.DDSketch) (*Sket
 // converting the DDSketch into a new DDSketch with a mapping that's compatible
 // with Sketch parameters, then creating the Sketch by copying the DDSketch
 // bins to the Sketch store.
-func ConvertDDSketchIntoSketch(inputSketch *ddsketch.DDSketch) (*Sketch, error) {
+func ConvertDDSketchIntoSketch(inputSketch *ddsketch.DDSketch) (*Sketch16, error) {
 	sketchConfig := Default()
 
 	compatibleDDSketch, err := createDDSketchWithSketchMapping(sketchConfig, inputSketch)

--- a/pkg/quantile/ddsketch_test.go
+++ b/pkg/quantile/ddsketch_test.go
@@ -291,7 +291,7 @@ func TestConvertDDSketchIntoSketch(t *testing.T) {
 			assert.InDelta(
 				t,
 				convertedSketch.GetCount(),
-				outputSketch.Basic.Cnt,
+				outputSketch.Basic().Cnt,
 				acceptableFloatError,
 			)
 
@@ -301,7 +301,7 @@ func TestConvertDDSketchIntoSketch(t *testing.T) {
 			assert.InDelta(
 				t,
 				expectedMinValue,
-				outputSketch.Basic.Min,
+				outputSketch.Basic().Min,
 				acceptableFloatError,
 			)
 
@@ -311,7 +311,7 @@ func TestConvertDDSketchIntoSketch(t *testing.T) {
 			assert.InDelta(
 				t,
 				expectedMaxValue,
-				outputSketch.Basic.Max,
+				outputSketch.Basic().Max,
 				acceptableFloatError,
 			)
 

--- a/pkg/quantile/main_test.go
+++ b/pkg/quantile/main_test.go
@@ -154,7 +154,7 @@ func arange(t *testing.T, c *Config, args ...int) *Sketch {
 		t.Fatalf("too many args: %v", args)
 	}
 
-	s := &Sketch{}
+	s := &Sketch16{}
 	for i := start; i < stop; i += step {
 		s.Insert(c, float64(i))
 	}

--- a/pkg/quantile/main_test.go
+++ b/pkg/quantile/main_test.go
@@ -39,9 +39,9 @@ func ParseBuf(t *testing.T, dsl string) []float64 {
 //
 // NOTE: there is no guarantee that the sketch is correct (because we'd like to
 // test bad sketch handling)
-func ParseSketch(t *testing.T, dsl string) *Sketch {
+func ParseSketch(t *testing.T, dsl string) Sketch {
 	t.Helper()
-	s := &Sketch{}
+	s := &Sketch16{}
 	c := Default()
 
 	eachParsedToken(t, dsl, 16, func(k Key, n uint64) {
@@ -51,7 +51,7 @@ func ParseSketch(t *testing.T, dsl string) *Sketch {
 
 		s.count += int(n)
 		s.bins = append(s.bins, bin{k: k, n: uint16(n)})
-		s.Basic.InsertN(c.f64(k), float64(n))
+		s.Basic().InsertN(c.f64(k), float64(n))
 	})
 
 	return s

--- a/pkg/quantile/main_test.go
+++ b/pkg/quantile/main_test.go
@@ -39,9 +39,9 @@ func ParseBuf(t *testing.T, dsl string) []float64 {
 //
 // NOTE: there is no guarantee that the sketch is correct (because we'd like to
 // test bad sketch handling)
-func ParseSketch(t *testing.T, dsl string) Sketch {
+func ParseSketch(t *testing.T, dsl string) Sketch16 {
 	t.Helper()
-	s := &Sketch16{}
+	s := Sketch16{}
 	c := Default()
 
 	eachParsedToken(t, dsl, 16, func(k Key, n uint64) {
@@ -136,7 +136,7 @@ func eachParsedToken(t *testing.T, dsl string, bitSize uint, f func(Key, uint64)
 
 // arange is like np.arange, except it creates a sketch
 // inserting ([start,] stop[, step,]) values.
-func arange(t *testing.T, c *Config, args ...int) *Sketch {
+func arange(t *testing.T, c *Config, args ...int) *Sketch16 {
 	t.Helper()
 	var (
 		start, stop int
@@ -156,7 +156,7 @@ func arange(t *testing.T, c *Config, args ...int) *Sketch {
 
 	s := &Sketch16{}
 	for i := start; i < stop; i += step {
-		s.Insert(c, float64(i))
+		s.InsertVals(c, float64(i))
 	}
 
 	return s

--- a/pkg/quantile/pool.go
+++ b/pkg/quantile/pool.go
@@ -24,6 +24,13 @@ var (
 		},
 	}
 
+	binListPool32 = sync.Pool{
+		New: func() interface{} {
+			a := make([]bin32, 0, defaultBinListSize)
+			return &a
+		},
+	}
+
 	keyListPool = sync.Pool{
 		New: func() interface{} {
 			a := make([]Key, 0, defaultKeyListSize)
@@ -46,6 +53,15 @@ func getBinList() []bin {
 
 func putBinList(a []bin) {
 	binListPool.Put(&a)
+}
+
+func getBinList32() []bin32 {
+	a := *(binListPool32.Get().(*[]bin32))
+	return a[:0]
+}
+
+func putBinList32(a []bin32) {
+	binListPool32.Put(&a)
 }
 
 func getKeyList() []Key {

--- a/pkg/quantile/print.go
+++ b/pkg/quantile/print.go
@@ -45,7 +45,7 @@ func printBins(w io.Writer, bins []bin, maxPerLine int) {
 	}
 }
 
-func printSketch(w io.Writer, s *Sketch, c *Config) {
+func printSketch(w io.Writer, s Sketch, c *Config) {
 	fmt.Fprintln(w, "sketch:")
 	head := func(s string) {
 		fmt.Fprintln(w, indent(s, 1))
@@ -57,7 +57,7 @@ func printSketch(w io.Writer, s *Sketch, c *Config) {
 
 	// bins
 	head("bins:")
-	fmt.Fprintln(w, indent(s.bins.String(), 2))
+	fmt.Fprintln(w, indent(s.BinsString(), 2))
 
 	// size
 	head("size:")
@@ -69,7 +69,7 @@ func printSketch(w io.Writer, s *Sketch, c *Config) {
 	)
 	fmt.Fprint(w, "\n")
 	iprintf("len=%d cap=%d",
-		s.bins.Len(), s.bins.Cap())
+		s.BinsLen(), s.BinsCap())
 	fmt.Fprint(w, "\n")
 
 	// stats
@@ -82,7 +82,7 @@ func printSketch(w io.Writer, s *Sketch, c *Config) {
 		fmt.Fprintf(w, "%02g=%.2f", p, s.Quantile(c, p/100))
 	}
 	fmt.Fprint(w, "\n")
-	fmt.Fprintln(w, indent(s.Basic.String(), 2))
+	fmt.Fprintln(w, indent(s.Basic().String(), 2))
 }
 
 func indent(s string, level int) string {

--- a/pkg/quantile/print.go
+++ b/pkg/quantile/print.go
@@ -57,7 +57,7 @@ func printSketch(w io.Writer, s Sketch, c *Config) {
 
 	// bins
 	head("bins:")
-	fmt.Fprintln(w, indent(s.BinsString(), 2))
+	fmt.Fprintln(w, indent(s.String(), 2))
 
 	// size
 	head("size:")

--- a/pkg/quantile/sparse.go
+++ b/pkg/quantile/sparse.go
@@ -24,26 +24,26 @@ type Sketch16 struct {
 	BasicSummary summary.Summary `json:"summary"`
 }
 
-func (s Sketch16) String() string {
+func (s *Sketch16) String() string {
 	var b strings.Builder
 	// todo
 	// printSketch(&b, s, Default())
 	return b.String()
 }
 
-func (s Sketch16) BinsLen() int {
+func (s *Sketch16) BinsLen() int {
 	return len(s.bins)
 }
 
-func (s Sketch16) BinsCap() int {
+func (s *Sketch16) BinsCap() int {
 	return cap(s.bins)
 }
 
-func (s Sketch16) Count() uint64 {
+func (s *Sketch16) Count() uint64 {
 	return uint64(s.sparseStore.count)
 }
 
-func (s Sketch16) Basic() *summary.Summary {
+func (s *Sketch16) Basic() *summary.Summary {
 	return &s.BasicSummary
 }
 
@@ -51,7 +51,7 @@ func (s Sketch16) Basic() *summary.Summary {
 //
 //	used: uses len(bins)
 //	allocated: uses cap(bins)
-func (s Sketch16) MemSize() (used, allocated int) {
+func (s *Sketch16) MemSize() (used, allocated int) {
 	const (
 		basicSize = int(unsafe.Sizeof(summary.Summary{}))
 	)
@@ -62,12 +62,12 @@ func (s Sketch16) MemSize() (used, allocated int) {
 	return
 }
 
-func (s Sketch16) InsertKeys(c *Config, keys []Key) {
+func (s *Sketch16) InsertKeys(c *Config, keys []Key) {
 	s.sparseStore.insert(c, keys)
 }
 
 // InsertMany values into the sketch.
-func (s Sketch16) InsertMany(c *Config, values []float64) {
+func (s *Sketch16) InsertMany(c *Config, values []float64) {
 	keys := getKeyList()
 
 	for _, v := range values {
@@ -80,7 +80,7 @@ func (s Sketch16) InsertMany(c *Config, values []float64) {
 }
 
 // Reset sketch to its empty state.
-func (s Sketch16) Reset() {
+func (s *Sketch16) Reset() {
 	s.BasicSummary.Reset()
 	s.sparseStore.count = 0
 	s.bins = s.bins[:0] // TODO: just release to a size tiered pool.
@@ -88,7 +88,7 @@ func (s Sketch16) Reset() {
 
 // Insert a single value into the sketch.
 // NOTE: InsertMany is much more efficient.
-func (s Sketch16) InsertVals(c *Config, vals ...float64) {
+func (s *Sketch16) InsertVals(c *Config, vals ...float64) {
 	// TODO: remove this
 	s.InsertMany(c, vals)
 }
@@ -105,7 +105,7 @@ func (s *Sketch16) merge(c *Config, o *Sketch16) {
 //
 //		Quantile(c, q <= 0)  = min
 //	 Quantile(c, q >= 1)  = max
-func (s Sketch16) Quantile(c *Config, q float64) float64 {
+func (s *Sketch16) Quantile(c *Config, q float64) float64 {
 	switch {
 	case s.sparseStore.count == 0:
 		return 0
@@ -170,7 +170,7 @@ func (s *Sketch16) Copy() *Sketch16 {
 	return dst
 }
 
-func (s Sketch16) CopyAsSketch() Sketch {
+func (s *Sketch16) CopyAsSketch() Sketch {
 	return s.Copy()
 }
 

--- a/pkg/quantile/sparse.go
+++ b/pkg/quantile/sparse.go
@@ -62,7 +62,7 @@ func (s Sketch16) MemSize() (used, allocated int) {
 	return
 }
 
-func (s Sketch16) Insert(c *Config, keys []Key) {
+func (s Sketch16) InsertKeys(c *Config, keys []Key) {
 	s.sparseStore.insert(c, keys)
 }
 
@@ -75,7 +75,7 @@ func (s Sketch16) InsertMany(c *Config, values []float64) {
 		keys = append(keys, c.key(v))
 	}
 
-	s.insert(c, keys)
+	s.sparseStore.insert(c, keys)
 	putKeyList(keys)
 }
 
@@ -88,7 +88,7 @@ func (s Sketch16) Reset() {
 
 // Insert a single value into the sketch.
 // NOTE: InsertMany is much more efficient.
-func (s *Sketch16) InsertVals(c *Config, vals ...float64) {
+func (s Sketch16) InsertVals(c *Config, vals ...float64) {
 	// TODO: remove this
 	s.InsertMany(c, vals)
 }

--- a/pkg/quantile/sparse32.go
+++ b/pkg/quantile/sparse32.go
@@ -24,26 +24,26 @@ type Sketch32 struct {
 	BasicSummary summary.Summary `json:"summary"`
 }
 
-func (s Sketch32) String() string {
+func (s *Sketch32) String() string {
 	var b strings.Builder
 	// todo
 	// printSketch(&b, s, Default())
 	return b.String()
 }
 
-func (s Sketch32) BinsLen() int {
+func (s *Sketch32) BinsLen() int {
 	return len(s.bins)
 }
 
-func (s Sketch32) BinsCap() int {
+func (s *Sketch32) BinsCap() int {
 	return cap(s.bins)
 }
 
-func (s Sketch32) Count() uint64 {
+func (s *Sketch32) Count() uint64 {
 	return s.sparseStore32.count
 }
 
-func (s Sketch32) Basic() *summary.Summary {
+func (s *Sketch32) Basic() *summary.Summary {
 	return &s.BasicSummary
 }
 
@@ -51,7 +51,7 @@ func (s Sketch32) Basic() *summary.Summary {
 //
 //	used: uses len(bins)
 //	allocated: uses cap(bins)
-func (s Sketch32) MemSize() (used, allocated int) {
+func (s *Sketch32) MemSize() (used, allocated int) {
 	const (
 		basicSize = int(unsafe.Sizeof(summary.Summary{}))
 	)
@@ -62,12 +62,12 @@ func (s Sketch32) MemSize() (used, allocated int) {
 	return
 }
 
-func (s Sketch32) InsertKeys(c *Config, keys []Key) {
+func (s *Sketch32) InsertKeys(c *Config, keys []Key) {
 	s.sparseStore32.insert(c, keys)
 }
 
 // InsertMany values into the sketch.
-func (s Sketch32) InsertMany(c *Config, values []float64) {
+func (s *Sketch32) InsertMany(c *Config, values []float64) {
 	keys := getKeyList()
 
 	for _, v := range values {
@@ -80,7 +80,7 @@ func (s Sketch32) InsertMany(c *Config, values []float64) {
 }
 
 // Reset sketch to its empty state.
-func (s Sketch32) Reset() {
+func (s *Sketch32) Reset() {
 	s.BasicSummary.Reset()
 	s.count = 0
 	s.bins = s.bins[:0] // TODO: just release to a size tiered pool.
@@ -88,7 +88,7 @@ func (s Sketch32) Reset() {
 
 // Insert a single value into the sketch.
 // NOTE: InsertMany is much more efficient.
-func (s Sketch32) InsertVals(c *Config, vals ...float64) {
+func (s *Sketch32) InsertVals(c *Config, vals ...float64) {
 	// TODO: remove this
 	s.InsertMany(c, vals)
 }
@@ -105,7 +105,7 @@ func (s *Sketch32) merge(c *Config, o *Sketch32) {
 //
 //		Quantile(c, q <= 0)  = min
 //	 Quantile(c, q >= 1)  = max
-func (s Sketch32) Quantile(c *Config, q float64) float64 {
+func (s *Sketch32) Quantile(c *Config, q float64) float64 {
 	switch {
 	case s.count == 0:
 		return 0
@@ -166,7 +166,7 @@ func (s *Sketch32) Copy() *Sketch32 {
 	return dst
 }
 
-func (s Sketch32) CopyAsSketch() Sketch {
+func (s *Sketch32) CopyAsSketch() Sketch {
 	return s.Copy()
 }
 

--- a/pkg/quantile/sparse32.go
+++ b/pkg/quantile/sparse32.go
@@ -39,15 +39,12 @@ func (s Sketch32) BinsCap() int {
 	return cap(s.bins)
 }
 
-func (s Sketch32) Basic() *summary.Summary {
-	return &s.BasicSummary
+func (s Sketch32) Count() uint64 {
+	return s.sparseStore32.count
 }
 
-func (s Sketch32) BinsString() string {
-	var b strings.Builder
-	// todo
-	// printBins(&b, s.bins, defaultBinPerLine)
-	return b.String()
+func (s Sketch32) Basic() *summary.Summary {
+	return &s.BasicSummary
 }
 
 // MemSize returns memory use in bytes:
@@ -66,7 +63,7 @@ func (s Sketch32) MemSize() (used, allocated int) {
 }
 
 func (s Sketch32) Insert(c *Config, keys []Key) {
-	// todo
+	s.sparseStore32.insert(c, keys)
 }
 
 // InsertMany values into the sketch.
@@ -87,11 +84,6 @@ func (s Sketch32) Reset() {
 	s.BasicSummary.Reset()
 	s.count = 0
 	s.bins = s.bins[:0] // TODO: just release to a size tiered pool.
-}
-
-// GetRawBins return raw bins information as string
-func (s *Sketch32) GetRawBins() (int, string) {
-	return s.count, strings.Replace(s.BinsString(), "\n", "", -1)
 }
 
 // Insert a single value into the sketch.

--- a/pkg/quantile/sparse32.go
+++ b/pkg/quantile/sparse32.go
@@ -62,7 +62,7 @@ func (s Sketch32) MemSize() (used, allocated int) {
 	return
 }
 
-func (s Sketch32) Insert(c *Config, keys []Key) {
+func (s Sketch32) InsertKeys(c *Config, keys []Key) {
 	s.sparseStore32.insert(c, keys)
 }
 
@@ -88,7 +88,7 @@ func (s Sketch32) Reset() {
 
 // Insert a single value into the sketch.
 // NOTE: InsertMany is much more efficient.
-func (s *Sketch32) InsertVals(c *Config, vals ...float64) {
+func (s Sketch32) InsertVals(c *Config, vals ...float64) {
 	// TODO: remove this
 	s.InsertMany(c, vals)
 }

--- a/pkg/quantile/sparse_test.go
+++ b/pkg/quantile/sparse_test.go
@@ -28,13 +28,13 @@ func TestMerge(t *testing.T) {
 
 	for i := -50; i <= 50; i++ {
 		v := float64(i)
-		sInsert.Insert(c, v)
+		sInsert.InsertVals(c, v)
 
 		values = append(values, v)
 		if i&1 == 0 {
-			s1.Insert(c, v)
+			s1.InsertVals(c, v)
 		} else {
-			s2.Insert(c, v)
+			s2.InsertVals(c, v)
 		}
 	}
 

--- a/pkg/quantile/sparse_test.go
+++ b/pkg/quantile/sparse_test.go
@@ -20,10 +20,10 @@ func TestMerge(t *testing.T) {
 		c      = Default()
 		values []float64
 
-		s1          = &Sketch{}
-		s2          = &Sketch{}
-		sInsert     = &Sketch{}
-		sInsertMany = &Sketch{}
+		s1          = &Sketch16{}
+		s2          = &Sketch16{}
+		sInsert     = &Sketch16{}
+		sInsertMany = &Sketch16{}
 	)
 
 	for i := -50; i <= 50; i++ {

--- a/pkg/quantile/store.go
+++ b/pkg/quantile/store.go
@@ -18,7 +18,7 @@ type sparseStore struct {
 }
 
 // Cols returns an array of k and n.
-func (s sparseStore) Cols() (k []int32, n []uint32) {
+func (s *sparseStore) Cols() (k []int32, n []uint32) {
 	if len(s.bins) == 0 {
 		return
 	}

--- a/pkg/quantile/store32.go
+++ b/pkg/quantile/store32.go
@@ -18,7 +18,7 @@ type sparseStore32 struct {
 }
 
 // Cols returns an array of k and n.
-func (s sparseStore32) Cols() (k []int32, n []uint32) {
+func (s *sparseStore32) Cols() (k []int32, n []uint32) {
 	if len(s.bins) == 0 {
 		return
 	}

--- a/pkg/quantile/store32.go
+++ b/pkg/quantile/store32.go
@@ -14,7 +14,7 @@ var _ memSized = (*sparseStore32)(nil)
 
 type sparseStore32 struct {
 	bins  binList32
-	count int
+	count uint64
 }
 
 // Cols returns an array of k and n.
@@ -168,11 +168,11 @@ func (s sparseStore32) InsertCounts(c *Config, kcs []KeyCount) {
 		case b.k > vk:
 			// When vk[i] == vk[i+1] we need to make sure they go in the same bucket.
 			tmp = appendSafe32(tmp, vk, kn)
-			s.count += kn
+			s.count += uint64(kn)
 			keyIdx++
 		default:
 			tmp = appendSafe32(tmp, b.k, int(b.n)+kn)
-			s.count += kn
+			s.count += uint64(kn)
 			sIdx++
 			keyIdx++
 		}
@@ -183,7 +183,7 @@ func (s sparseStore32) InsertCounts(c *Config, kcs []KeyCount) {
 	for keyIdx < len(kcs) {
 		kn := int(kcs[keyIdx].n)
 		tmp = appendSafe32(tmp, kcs[keyIdx].k, kn)
-		s.count += kn
+		s.count += uint64(kn)
 		keyIdx++
 	}
 
@@ -196,7 +196,7 @@ func (s sparseStore32) InsertCounts(c *Config, kcs []KeyCount) {
 }
 
 func (s *sparseStore32) insert(c *Config, keys []Key) {
-	s.count += len(keys)
+	s.count += uint64(len(keys))
 
 	// TODO|PERF: A custom uint16 sort should easily beat sort.Sort.
 	// TODO|PERF: Would it be cheaper to sort float64s and then convert to keys?

--- a/pkg/quantile/summary/summary.go
+++ b/pkg/quantile/summary/summary.go
@@ -23,7 +23,7 @@ func (s *Summary) Reset() {
 	*s = Summary{}
 }
 
-func (s *Summary) String() string {
+func (s Summary) String() string {
 	return fmt.Sprintf("min=%.4f max=%.4f avg=%.4f sum=%.4f cnt=%d",
 		s.Min, s.Max, s.Avg, s.Sum, s.Cnt)
 }

--- a/pkg/quantile/types.go
+++ b/pkg/quantile/types.go
@@ -13,11 +13,13 @@ type Sketch interface {
 	InsertCounts(c *Config, kcs []KeyCount)
 	Reset()
 
+	Count() uint64
+	String() string
+
 	CopyAsSketch() Sketch
 	Cols() (k []int32, n []uint32)
 	Basic() *summary.Summary
 
-	BinsString() string
 	MemSize() (used, allocated int)
 	BinsLen() int
 	BinsCap() int

--- a/pkg/quantile/types.go
+++ b/pkg/quantile/types.go
@@ -8,7 +8,8 @@ package quantile
 import "github.com/DataDog/opentelemetry-mapping-go/pkg/quantile/summary"
 
 type Sketch interface {
-	Insert(c *Config, values []Key)
+	InsertKeys(c *Config, values []Key)
+	InsertVals(c *Config, vals ...float64)
 	InsertMany(c *Config, values []float64)
 	InsertCounts(c *Config, kcs []KeyCount)
 	Reset()

--- a/pkg/quantile/types.go
+++ b/pkg/quantile/types.go
@@ -8,21 +8,20 @@ package quantile
 import "github.com/DataDog/opentelemetry-mapping-go/pkg/quantile/summary"
 
 type Sketch interface {
-	InsertKeys(c *Config, values []Key)
-	InsertVals(c *Config, vals ...float64)
-	InsertMany(c *Config, values []float64)
 	InsertCounts(c *Config, kcs []KeyCount)
+	InsertKeys(c *Config, values []Key)
+	InsertMany(c *Config, values []float64)
+	InsertVals(c *Config, vals ...float64)
 	Reset()
 
-	Count() uint64
-	String() string
-
-	CopyAsSketch() Sketch
-	Cols() (k []int32, n []uint32)
 	Basic() *summary.Summary
+	Cols() (k []int32, n []uint32)
 
-	MemSize() (used, allocated int)
-	BinsLen() int
 	BinsCap() int
+	BinsLen() int
+	CopyAsSketch() Sketch
+	Count() uint64
+	MemSize() (used, allocated int)
 	Quantile(c *Config, q float64) float64
+	String() string
 }

--- a/pkg/quantile/types.go
+++ b/pkg/quantile/types.go
@@ -1,0 +1,25 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package quantile
+
+import "github.com/DataDog/opentelemetry-mapping-go/pkg/quantile/summary"
+
+type Sketch interface {
+	Insert(c *Config, values []Key)
+	InsertMany(c *Config, values []float64)
+	InsertCounts(c *Config, kcs []KeyCount)
+	Reset()
+
+	CopyAsSketch() Sketch
+	Cols() (k []int32, n []uint32)
+	Basic() *summary.Summary
+
+	BinsString() string
+	MemSize() (used, allocated int)
+	BinsLen() int
+	BinsCap() int
+	Quantile(c *Config, q float64) float64
+}


### PR DESCRIPTION
### What does this PR do?

Add a sparse store with 32-bit bins. We have observed that this offers a significant performance increase for distributions (tests in https://github.com/DataDog/datadog-agent/pull/20565 and sibling PRs).

Make the `Agent` buffer use a sketch interface to allow us to put this behind a config flag.

Pairs with: https://github.com/DataDog/datadog-agent/pull/20695

Ref https://datadoghq.atlassian.net/browse/SMPTNG-72

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

