### PR TITLE
Quantile: Add support for 32-bit bins

### DIFF
--- a/pkg/otlp/metrics/consumer.go
+++ b/pkg/otlp/metrics/consumer.go
@@ -80,7 +80,7 @@ type SketchConsumer interface {
 		ctx context.Context,
 		dimensions *Dimensions,
 		timestamp uint64,
-		sketch *quantile.Sketch,
+		sketch quantile.SketchReader,
 	)
 }
 

--- a/pkg/otlp/metrics/exponential_histograms_translator.go
+++ b/pkg/otlp/metrics/exponential_histograms_translator.go
@@ -145,7 +145,7 @@ func (t *Translator) mapExponentialHistogramMetrics(
 			continue
 		}
 
-		agentSketch, err := quantile.ConvertDDSketchIntoSketch(expHistDDSketch)
+		agentSketch, err := quantile.ConvertDDSketchIntoSketch[uint16](expHistDDSketch)
 		if err != nil {
 			t.logger.Debug("Failed to convert DDSketch into Sketch",
 				zap.String("metric name", dims.name),

--- a/pkg/quantile/bin_test.go
+++ b/pkg/quantile/bin_test.go
@@ -12,33 +12,42 @@ import (
 )
 
 func TestBin_incrSafe(t *testing.T) {
-	const maxn = maxBinWidth
+	t.Run("uint16", func(t *testing.T) {
+		testBin_incrSafe[uint16](t)
+	})
+	t.Run("uint32", func(t *testing.T) {
+		testBin_incrSafe[uint32](t)
+	})
+}
+
+func testBin_incrSafe[T uint16 | uint32](t *testing.T) {
+	maxn := maxBinWidth[T]()
 	tests := []struct {
-		n            uint16
-		by           int
-		wantN        uint16
-		wantOverflow int
+		n            T
+		by           uint64
+		wantN        T
+		wantOverflow uint64
 		name         string
 	}{
 		{by: 1, wantN: 1},
 		{n: 1, by: 1, wantN: 2},
 		{n: maxn, by: 1, wantN: maxn, wantOverflow: 1},
-		{by: maxn, wantN: maxn},
-		{n: 1, by: maxn, wantN: maxn, wantOverflow: 1},
-		{n: 100, by: 3 * maxn, wantN: maxn, wantOverflow: 2*maxn + 100},
+		{by: uint64(maxn), wantN: maxn},
+		{n: 1, by: uint64(maxn), wantN: maxn, wantOverflow: 1},
+		{n: 100, by: uint64(3 * maxn), wantN: maxn, wantOverflow: uint64(2*maxn + 100)},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 
 			var (
-				b           = bin{n: tt.n}
-				gotOverflow = b.incrSafe(tt.by)
+				b           = bin[T]{n: tt.n}
+				gotOverflow = b.incrSafe(int(tt.by)) // this will fail for T uint32
 				errs        []string
 				ok          = true
 			)
 
-			if tt.wantOverflow != gotOverflow {
+			if tt.wantOverflow != uint64(gotOverflow) {
 				ok = false
 				errs = append(errs, fmt.Sprintf("\toverflow: got %d, want %d",
 					gotOverflow, tt.wantOverflow))

--- a/pkg/quantile/ddsketch_test.go
+++ b/pkg/quantile/ddsketch_test.go
@@ -179,6 +179,15 @@ func TestCreateDDSketchWithSketchMapping(t *testing.T) {
 }
 
 func TestConvertDDSketchIntoSketch(t *testing.T) {
+	t.Run("uint16", func(t *testing.T) {
+		testConvertDDSketchIntoSketch[uint16](t)
+	})
+	t.Run("uint32", func(t *testing.T) {
+		testConvertDDSketchIntoSketch[uint32](t)
+	})
+}
+
+func testConvertDDSketchIntoSketch[T uint16 | uint32](t *testing.T) {
 	// Support of the distribution: [0,N] or [-N,0]
 	N := 1_000.0
 	// Number of points per quantile
@@ -277,7 +286,7 @@ func TestConvertDDSketchIntoSketch(t *testing.T) {
 			convertedSketch, err := createDDSketchWithSketchMapping(sketchConfig, sketch)
 			require.NoError(t, err)
 
-			outputSketch, err := convertDDSketchIntoSketch(sketchConfig, convertedSketch)
+			outputSketch, err := convertDDSketchIntoSketch[T](sketchConfig, convertedSketch)
 			require.NoError(t, err)
 
 			// Conversion accuracy formula taken from:

--- a/pkg/quantile/pool.go
+++ b/pkg/quantile/pool.go
@@ -15,53 +15,58 @@ const (
 	defaultOverflowListSize = 16
 )
 
-var (
-	// TODO: multiple pools, one for each size class (like github.com/oxtoacart/bpool)
-	binListPool = sync.Pool{
-		New: func() interface{} {
-			a := make([]bin, 0, defaultBinListSize)
-			return &a
+type BinPool[T uint16 | uint32] struct {
+	binListPool      sync.Pool
+	keyListPool      sync.Pool
+	overflowListPool sync.Pool
+}
+
+func NewBinPool[T uint16 | uint32]() *BinPool[T] {
+	return &BinPool[T]{
+		binListPool: sync.Pool{
+			New: func() interface{} {
+				a := make([]bin[T], 0, defaultBinListSize)
+				return &a
+			},
+		},
+		keyListPool: sync.Pool{
+			New: func() interface{} {
+				a := make([]Key, 0, defaultKeyListSize)
+				return &a
+			},
+		},
+		overflowListPool: sync.Pool{
+			New: func() interface{} {
+				a := make([]bin[T], 0, defaultOverflowListSize)
+				return &a
+			},
 		},
 	}
+}
 
-	keyListPool = sync.Pool{
-		New: func() interface{} {
-			a := make([]Key, 0, defaultKeyListSize)
-			return &a
-		},
-	}
-
-	overflowListPool = sync.Pool{
-		New: func() interface{} {
-			a := make([]bin, 0, defaultOverflowListSize)
-			return &a
-		},
-	}
-)
-
-func getBinList() []bin {
-	a := *(binListPool.Get().(*[]bin))
+func (b *BinPool[T]) getBinList() []bin[T] {
+	a := *(b.binListPool.Get().(*[]bin[T]))
 	return a[:0]
 }
 
-func putBinList(a []bin) {
-	binListPool.Put(&a)
+func (b *BinPool[T]) putBinList(a []bin[T]) {
+	b.binListPool.Put(&a)
 }
 
-func getKeyList() []Key {
-	a := *(keyListPool.Get().(*[]Key))
+func (b *BinPool[T]) getKeyList() []Key {
+	a := *(b.keyListPool.Get().(*[]Key))
 	return a[:0]
 }
 
-func putKeyList(a []Key) {
-	keyListPool.Put(&a)
+func (b *BinPool[T]) putKeyList(a []Key) {
+	b.keyListPool.Put(&a)
 }
 
-func getOverflowList() []bin {
-	a := *(overflowListPool.Get().(*[]bin))
+func (b *BinPool[T]) getOverflowList() []bin[T] {
+	a := *(b.overflowListPool.Get().(*[]bin[T]))
 	return a[:0]
 }
 
-func putOverflowList(a []bin) {
-	overflowListPool.Put(&a)
+func (b *BinPool[T]) putOverflowList(a []bin[T]) {
+	b.overflowListPool.Put(&a)
 }

--- a/pkg/quantile/print.go
+++ b/pkg/quantile/print.go
@@ -30,7 +30,7 @@ type memSized interface {
 // output:
 //
 //	<k>:<n>...
-func printBins(w io.Writer, bins []bin, maxPerLine int) {
+func printBins[T uint16 | uint32](w io.Writer, bins []bin[T], maxPerLine int) {
 	for i, b := range bins {
 		prefix := ""
 
@@ -45,7 +45,7 @@ func printBins(w io.Writer, bins []bin, maxPerLine int) {
 	}
 }
 
-func printSketch(w io.Writer, s *Sketch, c *Config) {
+func printSketch[T uint16 | uint32](w io.Writer, s *Sketch[T], c *Config) {
 	fmt.Fprintln(w, "sketch:")
 	head := func(s string) {
 		fmt.Fprintln(w, indent(s, 1))

--- a/pkg/quantile/print_test.go
+++ b/pkg/quantile/print_test.go
@@ -14,15 +14,24 @@ import (
 )
 
 func TestPrintBins(t *testing.T) {
-	mb := func(dsl string) []bin {
-		s := ParseSketch(t, dsl)
+	t.Run("uint16", func(t *testing.T) {
+		testPrintBins[uint16](t)
+	})
+	t.Run("uint32", func(t *testing.T) {
+		testPrintBins[uint32](t)
+	})
+}
+
+func testPrintBins[T uint16 | uint32](t *testing.T) {
+	mb := func(dsl string) []bin[T] {
+		s := ParseSketch[T](t, dsl)
 		return s.bins
 	}
 
 	b10 := "0:1 1:1 2:1 3:1 4:1 5:1 6:1 7:1 8:1 9:1"
 
 	for _, tt := range []struct {
-		bins []bin
+		bins []bin[T]
 		w    int
 		exp  string
 	}{
@@ -67,9 +76,9 @@ func TestPrintBins(t *testing.T) {
 	}
 
 	t.Run("demo", func(t *testing.T) {
-		var bins binList
+		var bins binList[T]
 		for i := 0; i < defaultBinPerLine*2+1; i++ {
-			bins = append(bins, bin{k: Key(i), n: 1})
+			bins = append(bins, bin[T]{k: Key(i), n: 1})
 		}
 
 		s := bins.String()

--- a/pkg/quantile/sparse_test.go
+++ b/pkg/quantile/sparse_test.go
@@ -16,14 +16,23 @@ import (
 )
 
 func TestMerge(t *testing.T) {
+	t.Run("uint16", func(t *testing.T) {
+		testMerge[uint16](t)
+	})
+	t.Run("uint32", func(t *testing.T) {
+		testMerge[uint32](t)
+	})
+}
+
+func testMerge[T uint16 | uint32](t *testing.T) {
 	var (
 		c      = Default()
 		values []float64
 
-		s1          = &Sketch{}
-		s2          = &Sketch{}
-		sInsert     = &Sketch{}
-		sInsertMany = &Sketch{}
+		s1          = &Sketch[T]{}
+		s2          = &Sketch[T]{}
+		sInsert     = &Sketch[T]{}
+		sInsertMany = &Sketch[T]{}
 	)
 
 	for i := -50; i <= 50; i++ {
@@ -41,7 +50,7 @@ func TestMerge(t *testing.T) {
 	sInsertMany.InsertMany(c, values)
 	s1.Merge(c, s2)
 	require.Len(t, sInsert.bins, len(values))
-	for _, s := range []*Sketch{s1, sInsertMany, sInsert} {
+	for _, s := range []*Sketch[T]{s1, sInsertMany, sInsert} {
 		require.EqualValues(t, 0, s.Quantile(c, .50))
 		require.EqualValues(t, sInsert.Quantile(c, .99), -sInsert.Quantile(c, .01))
 		for p := 0; p < 50; p++ {
@@ -59,8 +68,17 @@ func TestMerge(t *testing.T) {
 }
 
 func TestString(t *testing.T) {
+	t.Run("uint16", func(t *testing.T) {
+		testString[uint16](t)
+	})
+	t.Run("uint32", func(t *testing.T) {
+		testString[uint32](t)
+	})
+}
+
+func testString[T uint16 | uint32](t *testing.T) {
 	var (
-		s, c    = &Sketch{}, Default()
+		s, c    = &Sketch[T]{}, Default()
 		nvalues = 5
 	)
 
@@ -73,8 +91,17 @@ func TestString(t *testing.T) {
 }
 
 func TestReset(t *testing.T) {
+	t.Run("uint16", func(t *testing.T) {
+		testReset[uint16](t)
+	})
+	t.Run("uint32", func(t *testing.T) {
+		testReset[uint32](t)
+	})
+}
+
+func testReset[T uint16 | uint32](t *testing.T) {
 	var (
-		s, c      = &Sketch{}, Default()
+		s, c      = &Sketch[T]{}, Default()
 		checkBins = func(nbins int) {
 			t.Helper()
 			switch {
@@ -104,17 +131,26 @@ func TestReset(t *testing.T) {
 	if s.Basic != empty {
 		t.Fatalf("%s should be empty", s.Basic.String())
 	}
-
 }
+
 func TestQuantile(t *testing.T) {
+	t.Run("uint16", func(t *testing.T) {
+		testQuantile[uint16](t)
+	})
+	t.Run("uint32", func(t *testing.T) {
+		testQuantile[uint32](t)
+	})
+}
+
+func testQuantile[T uint16 | uint32](t *testing.T) {
 	var (
 		c = Default()
 
 		// create a sketch with nbins bins.
-		create = func(nbins int) *Sketch {
+		create = func(nbins int) *Sketch[T] {
 			t.Helper()
 
-			s := &Sketch{}
+			s := &Sketch[T]{}
 			k := c.key(1)
 			for i := 0; i < nbins; i++ {
 				v := c.f64(k)
@@ -143,12 +179,12 @@ func TestQuantile(t *testing.T) {
 	)
 
 	type qtest struct {
-		s   *Sketch
+		s   *Sketch[T]
 		q   float64
 		exp float64
 	}
 
-	sIncr101 := arange(t, c, 101)
+	sIncr101 := arange[T](t, c, 101)
 	sBin101 := create(101)
 
 	for i, tt := range []qtest{
@@ -186,11 +222,20 @@ func IsClose(t *testing.T, expected, actual float64) {
 }
 
 func TestQuantileDDGo(t *testing.T) {
+	t.Run("uint16", func(t *testing.T) {
+		testQuantileDDGo[uint16](t)
+	})
+	t.Run("uint32", func(t *testing.T) {
+		testQuantileDDGo[uint32](t)
+	})
+}
+
+func testQuantileDDGo[T uint16 | uint32](t *testing.T) {
 	c := Default()
 	t.Run("Test count greater than sum of bins", func(t *testing.T) {
 		ta := require.New(t)
 
-		s := arange(t, c, 1, 101)
+		s := arange[T](t, c, 1, 101)
 		q := s.Quantile(c, .99)
 		ta.NotEqual(s.Basic.Max, q, "should not be max from sketch")
 

--- a/pkg/quantile/store_test.go
+++ b/pkg/quantile/store_test.go
@@ -6,7 +6,6 @@
 package quantile
 
 import (
-	"math"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -19,22 +18,31 @@ import (
 //
 // For example, `0:3 1:1 2:1 2:1 3:max`
 // TODO: move to main_test.go
-func buildStore(t *testing.T, dsl string) *sparseStore {
-	s := &sparseStore{}
+func buildStore[T uint16 | uint32](t *testing.T, dsl string) *sparseStore[T] {
+	s := &sparseStore[T]{}
 
-	eachParsedToken(t, dsl, 16, func(k Key, n uint64) {
-		if n > maxBinWidth {
-			t.Fatal("n > max", n, maxBinWidth)
+	eachParsedToken[T](t, dsl, bitSize[T](), func(k Key, n uint64) {
+		if n > uint64(maxBinWidth[T]()) {
+			t.Fatal("n > max", n, maxBinWidth[T]())
 		}
 
 		s.count += int(n)
-		s.bins = append(s.bins, bin{k: k, n: uint16(n)})
+		s.bins = append(s.bins, bin[T]{k: k, n: T(n)})
 	})
 
 	return s
 }
 
 func TestStore(t *testing.T) {
+	t.Run("uint16", func(t *testing.T) {
+		testStore[uint16](t)
+	})
+	t.Run("uint32", func(t *testing.T) {
+		testStore[uint32](t)
+	})
+}
+
+func testStore[T uint16 | uint32](t *testing.T) {
 	t.Run("merge", func(t *testing.T) {
 		type mt struct {
 			s, o, exp string
@@ -60,9 +68,9 @@ func TestStore(t *testing.T) {
 			t.Run("", func(t *testing.T) {
 				var (
 					c   = Default()
-					s   = buildStore(t, tt.s)
-					o   = buildStore(t, tt.o)
-					exp = buildStore(t, tt.exp)
+					s   = buildStore[T](t, tt.s)
+					o   = buildStore[T](t, tt.o)
+					exp = buildStore[T](t, tt.exp)
 				)
 
 				if tt.binLimit != 0 {
@@ -76,12 +84,14 @@ func TestStore(t *testing.T) {
 					t.Errorf("s.count=%d, want %d", s.count, exp.count)
 				}
 
-				if nsum := s.bins.nSum(); exp.count != nsum {
+				if nsum := s.bins.nSum(); exp.count != int(nsum) {
 					t.Errorf("nSum=%d, want %d", nsum, exp.count)
 				}
 
 				require.Equal(t, exp.bins.String(), s.bins.String())
-				require.EqualValues(t, exp, s)
+				// don't compare binPool (lazy initialized sync.Pools)
+				require.EqualValues(t, exp.count, s.count)
+				require.EqualValues(t, exp.bins, s.bins)
 			})
 		}
 
@@ -104,7 +114,7 @@ func TestStore(t *testing.T) {
 			},
 			{
 				s: "1:max 1:max 1:1 2:max 3:1 4:1",
-				e: "1:65535 1:65535 2:1 2:65535 3:1 4:1",
+				e: "1:max 1:max 2:1 2:max 3:1 4:1",
 				b: 3,
 			},
 			{
@@ -113,44 +123,44 @@ func TestStore(t *testing.T) {
 				b: 3,
 			},
 		} {
-
 			t.Run("", func(t *testing.T) {
 				var (
 					c   = Default()
-					s   = buildStore(t, tt.s)
-					exp = buildStore(t, tt.e)
+					s   = buildStore[T](t, tt.s)
+					exp = buildStore[T](t, tt.e)
 				)
 
 				if tt.b != 0 {
 					c.binLimit = tt.b
 				}
-				s.bins = trimLeft(s.bins, tt.b)
+				s.bins = s.trimLeft(s.bins, tt.b)
 
 				if exp.count != s.count {
 					t.Errorf("s.count=%d, want %d", s.count, exp.count)
 				}
 
-				if nsum := s.bins.nSum(); exp.count != nsum {
+				if nsum := s.bins.nSum(); exp.count != int(nsum) {
 					t.Errorf("nSum=%d, want %d", nsum, exp.count)
 				}
 
 				require.Equal(t, exp.bins.String(), s.bins.String())
-				require.EqualValues(t, exp, s)
+				// don't compare binPool (lazy initialized sync.Pools)
+				require.EqualValues(t, exp.count, s.count)
+				require.EqualValues(t, exp.bins, s.bins)
 			})
 		}
-
 	})
 
 	t.Run("insert", func(t *testing.T) {
 		type insertTest struct {
-			s    *sparseStore
+			s    *sparseStore[T]
 			keys []Key
 			exp  string
 		}
 
 		c := func(startState string, expected string, keys ...Key) insertTest {
 			return insertTest{
-				s:    buildStore(t, startState),
+				s:    buildStore[T](t, startState),
 				keys: keys,
 				exp:  expected,
 			}
@@ -175,26 +185,32 @@ func TestStore(t *testing.T) {
 				s := tt.s
 				s.insert(Default(), tt.keys)
 
-				exp := buildStore(t, tt.exp)
+				exp := buildStore[T](t, tt.exp)
 				if exp.count != s.count {
 					t.Errorf("s.count=%d, want %d", s.count, exp.count)
 				}
 
-				if nsum := s.bins.nSum(); exp.count != nsum {
+				if nsum := s.bins.nSum(); exp.count != int(nsum) {
 					t.Errorf("nSum=%d, want %d", nsum, exp.count)
 				}
 
 				require.Equal(t, exp.bins.String(), s.bins.String())
 				require.Equal(t, exp.bins, s.bins)
-
 			})
-
 		}
 	})
-
 }
 
 func TestCols(t *testing.T) {
+	t.Run("uint16", func(t *testing.T) {
+		testCols[uint16](t)
+	})
+	t.Run("uint32", func(t *testing.T) {
+		testCols[uint32](t)
+	})
+}
+
+func testCols[T uint16 | uint32](t *testing.T) {
 	for _, tt := range []struct {
 		store string
 		k     []int32
@@ -206,15 +222,15 @@ func TestCols(t *testing.T) {
 		{
 			store: "0:1 1:1 2:2 3:1 4:1 5:1 8:1 9:1 10:max",
 			k:     []int32{0, 1, 2, 3, 4, 5, 8, 9, 10},
-			n:     []uint32{1, 1, 2, 1, 1, 1, 1, 1, math.MaxUint16},
+			n:     []uint32{1, 1, 2, 1, 1, 1, 1, 1, uint32(maxBinWidth[T]())},
 		},
 		{
 			store: "0:1 0:max",
 			k:     []int32{0, 0},
-			n:     []uint32{1, math.MaxUint16},
+			n:     []uint32{1, uint32(maxBinWidth[T]())},
 		},
 	} {
-		st := buildStore(t, tt.store)
+		st := buildStore[T](t, tt.store)
 		k, n := st.Cols()
 		assert.Equal(t, k, tt.k, "keys don't match")
 		assert.Equal(t, n, tt.n, "values don't match")

--- a/pkg/quantile/store_test.go
+++ b/pkg/quantile/store_test.go
@@ -183,7 +183,7 @@ func testStore[T uint16 | uint32](t *testing.T) {
 			// TODO|TEST: that we never exceed binLimit.
 			t.Run("", func(t *testing.T) {
 				s := tt.s
-				s.insert(Default(), tt.keys)
+				s.InsertKeys(Default(), tt.keys)
 
 				exp := buildStore[T](t, tt.exp)
 				if exp.count != s.count {

--- a/pkg/quantile/summary/summary.go
+++ b/pkg/quantile/summary/summary.go
@@ -18,6 +18,11 @@ type Summary struct {
 	Cnt int64
 }
 
+// Compare two summaries
+func (s *Summary) Equals(other *Summary) bool {
+	return s.Min == other.Min && s.Max == other.Max && s.Sum == other.Sum && s.Avg == other.Avg && s.Cnt == other.Cnt
+}
+
 // Reset the summary
 func (s *Summary) Reset() {
 	*s = Summary{}

--- a/pkg/quantile/test_helper.go
+++ b/pkg/quantile/test_helper.go
@@ -17,42 +17,91 @@ func almostEqual(a, b, e float64) bool {
 }
 
 // SketchesApproxEqual checks whether two SketchSeries are equal
-func SketchesApproxEqual(exp, act *Sketch, e float64) bool {
+func SketchesApproxEqual(exp, act SketchReader, e float64) bool {
 
-	if !almostEqual(exp.Basic.Sum, act.Basic.Sum, e) {
+	if !almostEqual(exp.Summary().Sum, act.Summary().Sum, e) {
 		return false
 	}
 
-	if !almostEqual(exp.Basic.Avg, act.Basic.Avg, e) {
+	if !almostEqual(exp.Summary().Avg, act.Summary().Avg, e) {
 		return false
 	}
 
-	if !almostEqual(exp.Basic.Max, act.Basic.Max, e) {
+	if !almostEqual(exp.Summary().Max, act.Summary().Max, e) {
 		return false
 	}
 
-	if !almostEqual(exp.Basic.Min, act.Basic.Min, e) {
+	if !almostEqual(exp.Summary().Min, act.Summary().Min, e) {
 		return false
 	}
 
-	if exp.Basic.Cnt != exp.Basic.Cnt {
+	if exp.Summary().Cnt != exp.Summary().Cnt {
 		return false
 	}
 
-	if exp.count != act.count {
+	if exp.Count() != act.Count() {
 		return false
 	}
 
-	if len(exp.bins) != len(act.bins) {
+	exp_keys, exp_vals := exp.Cols()
+	act_keys, act_vals := act.Cols()
+
+	if len(exp_keys) != len(act_keys) {
 		return false
 	}
 
-	for i := range exp.bins {
-		if math.Abs(float64(act.bins[i].k-exp.bins[i].k)) > 1 {
+	for i := range exp_keys {
+		if math.Abs(float64(act_keys[i]-exp_keys[i])) > 1 {
 			return false
 		}
 
-		if act.bins[i].n != exp.bins[i].n {
+		if act_vals[i] != exp_vals[i] {
+			return false
+		}
+	}
+
+	return true
+}
+
+// SketchesEqual checks whether two SketchSeries are equal
+func SketchesEqual(exp, act SketchReader) bool {
+	if exp.Summary().Sum != act.Summary().Sum {
+		return false
+	}
+
+	if exp.Summary().Avg != act.Summary().Avg {
+		return false
+	}
+
+	if exp.Summary().Max != act.Summary().Max {
+		return false
+	}
+
+	if exp.Summary().Min != act.Summary().Min {
+		return false
+	}
+
+	if exp.Summary().Cnt != exp.Summary().Cnt {
+		return false
+	}
+
+	if exp.Count() != act.Count() {
+		return false
+	}
+
+	exp_keys, exp_vals := exp.Cols()
+	act_keys, act_vals := act.Cols()
+
+	if len(exp_keys) != len(act_keys) {
+		return false
+	}
+
+	for i := range exp_keys {
+		if act_keys[i] != exp_keys[i] {
+			return false
+		}
+
+		if act_vals[i] != exp_vals[i] {
 			return false
 		}
 	}

--- a/pkg/quantile/types.go
+++ b/pkg/quantile/types.go
@@ -12,6 +12,12 @@ type SketchReader interface {
 	Cols() (k []int32, n []uint32)
 	Count() int
 	CopyInterface() SketchReader
+
+	SketchDebug
+}
+
+type SketchDebug interface {
+	String() string
 }
 
 type SketchWriter interface {

--- a/pkg/quantile/types.go
+++ b/pkg/quantile/types.go
@@ -1,0 +1,26 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2016-present Datadog, Inc.
+
+package quantile
+
+import "github.com/DataDog/opentelemetry-mapping-go/pkg/quantile/summary"
+
+type SketchReader interface {
+	Summary() *summary.Summary
+	Cols() (k []int32, n []uint32)
+	Count() int
+	CopyInterface() SketchReader
+}
+
+type SketchWriter interface {
+	Reset()
+	InsertKeys(c *Config, keys []Key)
+	InsertCounts(c *Config, kcs []KeyCount)
+}
+
+type SketchRW interface {
+	SketchReader
+	SketchWriter
+}


### PR DESCRIPTION
### What does this PR do?

This change makes sketches generic over bin size and introduces a set of interfaces for interacting with them.

The generic boundary is placed below the `Agent` sketch, which is effectively a buffer. This keeps interface overhead low. Buffering is enabled for `Agent.CountBuf` for the same reason. This results in a performance improvement across the board but the main goal there was to avoid a regression from interface overhead.

This change is sibling to: https://github.com/DataDog/datadog-agent/pull/20770

### Motivation

This nets us a very significant performance win in datadog-agent's distribution handling. 