### PR TITLE
Add functionality for runtime metric mappings to sum values by attribute

### DIFF
--- a/pkg/otlp/metrics/metrics_translator_test.go
+++ b/pkg/otlp/metrics/metrics_translator_test.go
@@ -607,7 +607,7 @@ func TestMapRuntimeMetricWithTwoAttributesHasMapping(t *testing.T) {
 		consumer.metrics,
 		[]metric{
 			newGaugeWithHost(newDims("process.runtime.jvm.memory.usage").AddTags("pool:G1 Old Gen", "type:heap"), uint64(seconds(startTs+1)), 10, fallbackHostname),
-			newGaugeWithHost(newDims("jvm.heap_memory").AddTags("pool:G1 Old Gen"), uint64(seconds(startTs+1)), 10, fallbackHostname),
+			newGaugeWithHost(newDims("jvm.heap_memory"), uint64(seconds(startTs+1)), 10, fallbackHostname),
 			newGaugeWithHost(newDims("jvm.gc.old_gen_size"), uint64(seconds(startTs+1)), 10, fallbackHostname),
 		},
 	)
@@ -636,9 +636,7 @@ func TestMapRuntimeMetricWithTwoAttributesMultipleDataPointsHasMapping(t *testin
 			newGaugeWithHost(newDims("process.runtime.jvm.memory.usage").AddTags("pool:G1 Old Gen", "type:heap"), uint64(seconds(startTs+1)), 10, fallbackHostname),
 			newGaugeWithHost(newDims("process.runtime.jvm.memory.usage").AddTags("pool:G1 Survivor Space", "type:heap"), uint64(seconds(startTs+2)), 20, fallbackHostname),
 			newGaugeWithHost(newDims("process.runtime.jvm.memory.usage").AddTags("pool:G1 Eden Space", "type:heap"), uint64(seconds(startTs+3)), 30, fallbackHostname),
-			newGaugeWithHost(newDims("jvm.heap_memory").AddTags("pool:G1 Old Gen"), uint64(seconds(startTs+1)), 10, fallbackHostname),
-			newGaugeWithHost(newDims("jvm.heap_memory").AddTags("pool:G1 Survivor Space"), uint64(seconds(startTs+2)), 20, fallbackHostname),
-			newGaugeWithHost(newDims("jvm.heap_memory").AddTags("pool:G1 Eden Space"), uint64(seconds(startTs+3)), 30, fallbackHostname),
+			newGaugeWithHost(newDims("jvm.heap_memory"), uint64(seconds(startTs+1)), 60, fallbackHostname),
 			newGaugeWithHost(newDims("jvm.gc.old_gen_size"), uint64(seconds(startTs+1)), 10, fallbackHostname),
 			newGaugeWithHost(newDims("jvm.gc.survivor_size"), uint64(seconds(startTs+2)), 20, fallbackHostname),
 			newGaugeWithHost(newDims("jvm.gc.eden_size"), uint64(seconds(startTs+3)), 30, fallbackHostname),

--- a/pkg/otlp/metrics/runtime_metric_mappings.go
+++ b/pkg/otlp/metrics/runtime_metric_mappings.go
@@ -10,8 +10,9 @@ var runtimeMetricPrefixLanguageMap = map[string]string{
 // runtimeMetricMapping defines the fields needed to map OTel runtime metrics to their equivalent
 // Datadog runtime metrics
 type runtimeMetricMapping struct {
-	mappedName string                   // the Datadog runtime metric name
-	attributes []runtimeMetricAttribute // the attribute(s) this metric originates from
+	mappedName      string                   // the Datadog runtime metric name
+	attributes      []runtimeMetricAttribute // the attribute(s) this metric originates from
+	sumAttributeKey string                   // the key of the attribute to sum values over
 }
 
 // runtimeMetricAttribute defines the structure for an attribute in regard to mapping runtime metrics.
@@ -101,12 +102,14 @@ var javaRuntimeMetricsMappings = runtimeMetricMappingList{
 			key:    "type",
 			values: []string{"heap"},
 		}},
+		sumAttributeKey: "pool",
 	}, {
 		mappedName: "jvm.non_heap_memory",
 		attributes: []runtimeMetricAttribute{{
 			key:    "type",
 			values: []string{"non_heap"},
 		}},
+		sumAttributeKey: "pool",
 	}, {
 		mappedName: "jvm.gc.old_gen_size",
 		attributes: []runtimeMetricAttribute{{
@@ -150,12 +153,14 @@ var javaRuntimeMetricsMappings = runtimeMetricMappingList{
 			key:    "type",
 			values: []string{"heap"},
 		}},
+		sumAttributeKey: "pool",
 	}, {
 		mappedName: "jvm.non_heap_memory_committed",
 		attributes: []runtimeMetricAttribute{{
 			key:    "type",
 			values: []string{"non_heap"},
 		}},
+		sumAttributeKey: "pool",
 	}},
 	"process.runtime.jvm.memory.init": {{
 		mappedName: "jvm.heap_memory_init",
@@ -163,12 +168,14 @@ var javaRuntimeMetricsMappings = runtimeMetricMappingList{
 			key:    "type",
 			values: []string{"heap"},
 		}},
+		sumAttributeKey: "pool",
 	}, {
 		mappedName: "jvm.non_heap_memory_init",
 		attributes: []runtimeMetricAttribute{{
 			key:    "type",
 			values: []string{"non_heap"},
 		}},
+		sumAttributeKey: "pool",
 	}},
 	"process.runtime.jvm.memory.limit": {{
 		mappedName: "jvm.heap_memory_max",
@@ -176,12 +183,14 @@ var javaRuntimeMetricsMappings = runtimeMetricMappingList{
 			key:    "type",
 			values: []string{"heap"},
 		}},
+		sumAttributeKey: "pool",
 	}, {
 		mappedName: "jvm.non_heap_memory_max",
 		attributes: []runtimeMetricAttribute{{
 			key:    "type",
 			values: []string{"non_heap"},
 		}},
+		sumAttributeKey: "pool",
 	}},
 	"process.runtime.jvm.buffer.usage": {{
 		mappedName: "jvm.buffer_pool.direct.used",


### PR DESCRIPTION
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

This PR refactors the runtime metrics mapping code and adds functionality to sum values by a specified attribute key. For example, the OTel metric `process.runtime.jvm.memory.usage` divides its values by different memory pools, which is designated by the `pool` attribute. In order to correctly map this metric to the DD metric `jvm.heap_memory`, we need to sum all the data point values with attribute `type: heap` and `pool:[any value]`. This applies to all of the JVM metrics that are divided by memory pools: 
- `process.runtime.jvm.memory.usage`
- `process.runtime.jvm.memory.committed`
- `process.runtime.jvm.memory.init`
- `process.runtime.jvm.memory.limit`.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

- https://datadoghq.atlassian.net/browse/OTEL-1139
- https://datadoghq.atlassian.net/browse/OTELS-110

