### PR TITLE
[pkg/otlp/metrics] Initial support for metrics origin

### DIFF
--- a/.chloggen/mx-psi_dimensions-change.yaml
+++ b/.chloggen/mx-psi_dimensions-change.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component (e.g. pkg/quantile)
+component: pkg/otlp/metrics
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add support for metrics origin in `Dimensions`.
+
+# The PR related to this change
+issues: [204]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/pkg/otlp/metrics/dimensions.go
+++ b/pkg/otlp/metrics/dimensions.go
@@ -36,6 +36,10 @@ type Dimensions struct {
 	tags     []string
 	host     string
 	originID string
+
+	originProduct  OriginProduct
+	originCategory OriginCategory
+	originService  OriginService
 }
 
 // Name of the metric.
@@ -58,6 +62,21 @@ func (d *Dimensions) OriginID() string {
 	return d.originID
 }
 
+// OriginProduct of the metric.
+func (d *Dimensions) OriginProduct() OriginProduct {
+	return d.originProduct
+}
+
+// OriginCategory of the metric.
+func (d *Dimensions) OriginCategory() OriginCategory {
+	return d.originCategory
+}
+
+// OriginService of the metric.
+func (d *Dimensions) OriginService() OriginService {
+	return d.originService
+}
+
 // getTags maps an attributeMap into a slice of Datadog tags
 func getTags(labels pcommon.Map) []string {
 	tags := make([]string, 0, labels.Len())
@@ -76,10 +95,13 @@ func (d *Dimensions) AddTags(tags ...string) *Dimensions {
 	newTags = append(newTags, tags...)
 	newTags = append(newTags, d.tags...)
 	return &Dimensions{
-		name:     d.name,
-		tags:     newTags,
-		host:     d.host,
-		originID: d.originID,
+		name:           d.name,
+		tags:           newTags,
+		host:           d.host,
+		originID:       d.originID,
+		originProduct:  d.originProduct,
+		originCategory: d.originCategory,
+		originService:  d.originService,
 	}
 }
 
@@ -91,10 +113,13 @@ func (d *Dimensions) WithAttributeMap(labels pcommon.Map) *Dimensions {
 // WithSuffix creates a new dimensions struct with an extra name suffix.
 func (d *Dimensions) WithSuffix(suffix string) *Dimensions {
 	return &Dimensions{
-		name:     fmt.Sprintf("%s.%s", d.name, suffix),
-		host:     d.host,
-		tags:     d.tags,
-		originID: d.originID,
+		name:           fmt.Sprintf("%s.%s", d.name, suffix),
+		host:           d.host,
+		tags:           d.tags,
+		originID:       d.originID,
+		originProduct:  d.originProduct,
+		originCategory: d.originCategory,
+		originService:  d.originService,
 	}
 }
 

--- a/pkg/otlp/metrics/origin.go
+++ b/pkg/otlp/metrics/origin.go
@@ -1,0 +1,24 @@
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package metrics
+
+// OriginProduct defines the origin product.
+type OriginProduct int32
+
+// OriginCategory defines the origin category.
+type OriginCategory int32
+
+// OriginService defines the origin service.
+type OriginService int32

--- a/pkg/otlp/metrics/testhelper_test.go
+++ b/pkg/otlp/metrics/testhelper_test.go
@@ -34,10 +34,13 @@ type TestMetrics struct {
 // TestDimensions copies the Dimensions struct with public fields.
 // NOTE: Keep this in sync with the Dimensions struct.
 type TestDimensions struct {
-	Name     string
-	Tags     []string
-	Host     string
-	OriginID string
+	Name           string
+	Tags           []string
+	Host           string
+	OriginID       string
+	OriginProduct  OriginProduct
+	OriginCategory OriginCategory
+	OriginService  OriginService
 }
 
 type TestSketch struct {
@@ -134,10 +137,13 @@ func (t *testConsumer) ConsumeTimeSeries(
 	t.testMetrics.TimeSeries = append(t.testMetrics.TimeSeries,
 		TestTimeSeries{
 			TestDimensions: TestDimensions{
-				Name:     dimensions.Name(),
-				Tags:     dimensions.Tags(),
-				Host:     dimensions.Host(),
-				OriginID: dimensions.OriginID(),
+				Name:           dimensions.Name(),
+				Tags:           dimensions.Tags(),
+				Host:           dimensions.Host(),
+				OriginID:       dimensions.OriginID(),
+				OriginProduct:  dimensions.OriginProduct(),
+				OriginCategory: dimensions.OriginCategory(),
+				OriginService:  dimensions.OriginService(),
 			},
 			Type:      typ,
 			Timestamp: timestamp,
@@ -155,10 +161,13 @@ func (t *testConsumer) ConsumeSketch(
 	t.testMetrics.Sketches = append(t.testMetrics.Sketches,
 		TestSketch{
 			TestDimensions: TestDimensions{
-				Name:     dimensions.Name(),
-				Tags:     dimensions.Tags(),
-				Host:     dimensions.Host(),
-				OriginID: dimensions.OriginID(),
+				Name:           dimensions.Name(),
+				Tags:           dimensions.Tags(),
+				Host:           dimensions.Host(),
+				OriginID:       dimensions.OriginID(),
+				OriginProduct:  dimensions.OriginProduct(),
+				OriginCategory: dimensions.OriginCategory(),
+				OriginService:  dimensions.OriginService(),
 			},
 			Timestamp: timestamp,
 			Summary:   sketch.Basic,


### PR DESCRIPTION
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Subset of #203 that I want to land first to be able to update the clients.

Right now all metrics will have unset origin product/service/category since this is the zero value.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Support for metrics origin
