### PR TITLE
OTEL-1171: Extract trace/span ID from `trace_id` and `span_id`

### DIFF
--- a/pkg/otlp/logs/logs_translator.go
+++ b/pkg/otlp/logs/logs_translator.go
@@ -85,7 +85,7 @@ func Transform(lr plog.LogRecord, res pcommon.Resource, logger *zap.Logger) data
 			l.Message = v.AsString()
 		case "status", "severity", "level", "syslog.severity":
 			status = v.AsString()
-		case "traceid", "contextmap.traceid", "oteltraceid":
+		case "traceid", "trace_id", "contextmap.traceid", "oteltraceid":
 			traceID, err := decodeTraceID(v.AsString())
 			if err != nil {
 				logger.Warn("failed to decode trace id",
@@ -97,7 +97,7 @@ func Transform(lr plog.LogRecord, res pcommon.Resource, logger *zap.Logger) data
 				l.AdditionalProperties[ddTraceID] = strconv.FormatUint(traceIDToUint64(traceID), 10)
 				l.AdditionalProperties[otelTraceID] = v.AsString()
 			}
-		case "spanid", "contextmap.spanid", "otelspanid":
+		case "spanid", "span_id", "contextmap.spanid", "otelspanid":
 			spanID, err := decodeSpanID(v.AsString())
 			if err != nil {
 				logger.Warn("failed to decode span id",

--- a/pkg/otlp/logs/logs_translator_test.go
+++ b/pkg/otlp/logs/logs_translator_test.go
@@ -218,6 +218,39 @@ func TestTransform(t *testing.T) {
 			},
 		},
 		{
+			name: "trace from attributes (underscore)",
+			args: args{
+				lr: func() plog.LogRecord {
+					l := plog.NewLogRecord()
+					l.Attributes().PutStr("app", "test")
+					l.Attributes().PutStr("span_id", "2e26da881214cd7c")
+					l.Attributes().PutStr("trace_id", "740112b325075be8c80a48de336ebc67")
+					l.Attributes().PutStr(conventions.AttributeServiceName, "otlp_col")
+					l.SetSeverityNumber(5)
+					return l
+				}(),
+				res: func() pcommon.Resource {
+					r := pcommon.NewResource()
+					return r
+				}(),
+			},
+			want: datadogV2.HTTPLogItem{
+				Ddtags:  datadog.PtrString(""),
+				Message: *datadog.PtrString(""),
+				Service: datadog.PtrString("otlp_col"),
+				AdditionalProperties: map[string]string{
+					"app":              "test",
+					"status":           "debug",
+					otelSeverityNumber: "5",
+					otelSpanID:         "2e26da881214cd7c",
+					otelTraceID:        "740112b325075be8c80a48de336ebc67",
+					ddSpanID:           "3325585652813450620",
+					ddTraceID:          "14414413676535528551",
+					"service.name":     "otlp_col",
+				},
+			},
+		},
+		{
 			name: "trace from attributes decode error",
 			args: args{
 				lr: func() plog.LogRecord {


### PR DESCRIPTION
### What does this PR do?

This PR extracts the trace and span ID from log attributes `trace_id` and `span_id`.


### Motivation

Remove need to add trace operator:
```
    operators:
      - type: json_parser
      - type: trace_parser
        trace_id:
          parse_from: attributes.trace_id
        span_id:
          parse_from: attributes.span_id
```
