### PR TITLE
Remove mapping for `process.runtime.jvm.gc.duration`

### DIFF
--- a/pkg/otlp/metrics/metrics_translator_test.go
+++ b/pkg/otlp/metrics/metrics_translator_test.go
@@ -537,7 +537,7 @@ func TestMapHistogramRuntimeMetricHasMapping(t *testing.T) {
 	tr := newTranslator(t, zap.NewNop())
 	consumer := &mockFullConsumer{}
 
-	rmt, err := tr.MapMetrics(ctx, createTestHistogramMetric("process.runtime.jvm.gc.duration"), consumer)
+	rmt, err := tr.MapMetrics(ctx, createTestHistogramMetric("process.runtime.jvm.threads.count"), consumer)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -545,14 +545,14 @@ func TestMapHistogramRuntimeMetricHasMapping(t *testing.T) {
 	assert.ElementsMatch(t,
 		consumer.metrics,
 		[]metric{
-			newCountWithHost(newDims("process.runtime.jvm.gc.duration.count"), uint64(seconds(startTs+1)), 100, fallbackHostname),
-			newCountWithHost(newDims("process.runtime.jvm.gc.duration.sum"), uint64(seconds(startTs+1)), 0, fallbackHostname),
-			newGaugeWithHost(newDims("process.runtime.jvm.gc.duration.min"), uint64(seconds(startTs+1)), -100, fallbackHostname),
-			newGaugeWithHost(newDims("process.runtime.jvm.gc.duration.max"), uint64(seconds(startTs+1)), 100, fallbackHostname),
-			newCountWithHost(newDims("jvm.gc.parnew.time.count"), uint64(seconds(startTs+1)), 100, fallbackHostname),
-			newCountWithHost(newDims("jvm.gc.parnew.time.sum"), uint64(seconds(startTs+1)), 0, fallbackHostname),
-			newGaugeWithHost(newDims("jvm.gc.parnew.time.min"), uint64(seconds(startTs+1)), -100, fallbackHostname),
-			newGaugeWithHost(newDims("jvm.gc.parnew.time.max"), uint64(seconds(startTs+1)), 100, fallbackHostname),
+			newCountWithHost(newDims("process.runtime.jvm.threads.count.count"), uint64(seconds(startTs+1)), 100, fallbackHostname),
+			newCountWithHost(newDims("process.runtime.jvm.threads.count.sum"), uint64(seconds(startTs+1)), 0, fallbackHostname),
+			newGaugeWithHost(newDims("process.runtime.jvm.threads.count.min"), uint64(seconds(startTs+1)), -100, fallbackHostname),
+			newGaugeWithHost(newDims("process.runtime.jvm.threads.count.max"), uint64(seconds(startTs+1)), 100, fallbackHostname),
+			newCountWithHost(newDims("jvm.thread_count.count"), uint64(seconds(startTs+1)), 100, fallbackHostname),
+			newCountWithHost(newDims("jvm.thread_count.sum"), uint64(seconds(startTs+1)), 0, fallbackHostname),
+			newGaugeWithHost(newDims("jvm.thread_count.min"), uint64(seconds(startTs+1)), -100, fallbackHostname),
+			newGaugeWithHost(newDims("jvm.thread_count.max"), uint64(seconds(startTs+1)), 100, fallbackHostname),
 		},
 	)
 	assert.Equal(t, []string{"jvm"}, rmt.Languages)

--- a/pkg/otlp/metrics/runtime_metric_mappings.go
+++ b/pkg/otlp/metrics/runtime_metric_mappings.go
@@ -94,7 +94,6 @@ var javaRuntimeMetricsMappings = runtimeMetricMappingList{
 	"process.runtime.jvm.classes.current_loaded": {{mappedName: "jvm.loaded_classes"}},
 	"process.runtime.jvm.system.cpu.utilization": {{mappedName: "jvm.cpu_load.system"}},
 	"process.runtime.jvm.cpu.utilization":        {{mappedName: "jvm.cpu_load.process"}},
-	"process.runtime.jvm.gc.duration":            {{mappedName: "jvm.gc.parnew.time"}},
 	"process.runtime.jvm.memory.usage": {{
 		mappedName: "jvm.heap_memory",
 		attributes: []runtimeMetricAttribute{{


### PR DESCRIPTION
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Removes runtime metric mapping for `process.runtime.jvm.gc.duration` -> `jvm.gc.parnew.time`.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

This mapping was causing problems due to the distribution overshadowing behavior in the backend. This is because `process.runtime.jvm.gc.duration` is an OTel histogram which gets converted to a DD distribution under the name of `jvm.gc.parnew.time`. This results in older `jvm.gc.parnew.time` values getting overridden because they're of type gauge.

