### PR TITLE
Remove ResourceAttributesAsTags

### DIFF
--- a/.chloggen/mackjmr_remove-unused-rattr-as-tags.yaml
+++ b/.chloggen/mackjmr_remove-unused-rattr-as-tags.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component (e.g. pkg/quantile)
+component: pkg/metrics
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Remove `WithResourceAttributesAsTags()` and `translatorConfig.ResourceAttributesAsTags`
+
+# The PR related to this change
+issues: [219]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/pkg/otlp/metrics/config.go
+++ b/pkg/otlp/metrics/config.go
@@ -27,10 +27,6 @@ type translatorConfig struct {
 	Quantiles                 bool
 	NumberMode                NumberMode
 	InitialCumulMonoValueMode InitialCumulMonoValueMode
-	ResourceAttributesAsTags  bool
-	// Deprecated: use InstrumentationScopeMetadataAsTags instead in favor of
-	// https://github.com/open-telemetry/opentelemetry-proto/releases/tag/v0.15.0
-	// Both must not be enabled at the same time.
 	InstrumentationLibraryMetadataAsTags bool
 	InstrumentationScopeMetadataAsTags   bool
 
@@ -91,14 +87,6 @@ func WithFallbackSourceProvider(provider source.Provider) TranslatorOption {
 func WithQuantiles() TranslatorOption {
 	return func(t *translatorConfig) error {
 		t.Quantiles = true
-		return nil
-	}
-}
-
-// WithResourceAttributesAsTags sets resource attributes as tags.
-func WithResourceAttributesAsTags() TranslatorOption {
-	return func(t *translatorConfig) error {
-		t.ResourceAttributesAsTags = true
 		return nil
 	}
 }

--- a/pkg/otlp/metrics/config.go
+++ b/pkg/otlp/metrics/config.go
@@ -22,11 +22,11 @@ import (
 
 type translatorConfig struct {
 	// metrics export behavior
-	HistMode                  HistogramMode
-	SendHistogramAggregations bool
-	Quantiles                 bool
-	NumberMode                NumberMode
-	InitialCumulMonoValueMode InitialCumulMonoValueMode
+	HistMode                             HistogramMode
+	SendHistogramAggregations            bool
+	Quantiles                            bool
+	NumberMode                           NumberMode
+	InitialCumulMonoValueMode            InitialCumulMonoValueMode
 	InstrumentationLibraryMetadataAsTags bool
 	InstrumentationScopeMetadataAsTags   bool
 

--- a/pkg/otlp/metrics/histograms_test.go
+++ b/pkg/otlp/metrics/histograms_test.go
@@ -190,9 +190,7 @@ func TestExponentialHistogramTranslatorOptions(t *testing.T) {
 			name:     "resource-attributes-as-tags",
 			otlpfile: "testdata/otlpdata/histogram/simple-exponential.json",
 			ddogfile: "testdata/datadogdata/histogram/simple-exponential_res-tags.json",
-			options: []TranslatorOption{
-				WithResourceAttributesAsTags(),
-			},
+			options: []TranslatorOption{},
 			expectedUnknownMetricType:                 1,
 			expectedUnsupportedAggregationTemporality: 1,
 		},
@@ -242,7 +240,6 @@ func TestExponentialHistogramTranslatorOptions(t *testing.T) {
 			otlpfile: "testdata/otlpdata/histogram/simple-exponential.json",
 			ddogfile: "testdata/datadogdata/histogram/simple-exponential_res-ilmd-tags.json",
 			options: []TranslatorOption{
-				WithResourceAttributesAsTags(),
 				WithInstrumentationLibraryMetadataAsTags(),
 			},
 			expectedUnknownMetricType:                 1,
@@ -254,7 +251,6 @@ func TestExponentialHistogramTranslatorOptions(t *testing.T) {
 			ddogfile: "testdata/datadogdata/histogram/simple-exponential_cs-both-tags.json",
 			options: []TranslatorOption{
 				WithHistogramAggregations(),
-				WithResourceAttributesAsTags(),
 				WithInstrumentationLibraryMetadataAsTags(),
 			},
 			expectedUnknownMetricType:                 1,
@@ -266,7 +262,6 @@ func TestExponentialHistogramTranslatorOptions(t *testing.T) {
 			ddogfile: "testdata/datadogdata/histogram/simple-exponential_all.json",
 			options: []TranslatorOption{
 				WithHistogramAggregations(),
-				WithResourceAttributesAsTags(),
 				WithInstrumentationLibraryMetadataAsTags(),
 				WithInstrumentationScopeMetadataAsTags(),
 			},

--- a/pkg/otlp/metrics/histograms_test.go
+++ b/pkg/otlp/metrics/histograms_test.go
@@ -187,11 +187,11 @@ func TestExponentialHistogramTranslatorOptions(t *testing.T) {
 			expectedUnsupportedAggregationTemporality: 1,
 		},
 		{
-			name:     "resource-attributes-as-tags",
-			otlpfile: "testdata/otlpdata/histogram/simple-exponential.json",
-			ddogfile: "testdata/datadogdata/histogram/simple-exponential_res-tags.json",
-			options: []TranslatorOption{},
-			expectedUnknownMetricType:                 1,
+			name:                      "resource-attributes-as-tags",
+			otlpfile:                  "testdata/otlpdata/histogram/simple-exponential.json",
+			ddogfile:                  "testdata/datadogdata/histogram/simple-exponential_res-tags.json",
+			options:                   []TranslatorOption{},
+			expectedUnknownMetricType: 1,
 			expectedUnsupportedAggregationTemporality: 1,
 		},
 		{

--- a/pkg/otlp/metrics/metrics_translator.go
+++ b/pkg/otlp/metrics/metrics_translator.go
@@ -69,7 +69,6 @@ func NewTranslator(logger *zap.Logger, options ...TranslatorOption) (*Translator
 		Quantiles:                            false,
 		NumberMode:                           NumberModeCumulativeToDelta,
 		InitialCumulMonoValueMode:            InitialCumulMonoValueModeAuto,
-		ResourceAttributesAsTags:             false,
 		InstrumentationLibraryMetadataAsTags: false,
 		sweepInterval:                        1800,
 		deltaTTL:                             3600,

--- a/pkg/otlp/metrics/mixed_metrics_test.go
+++ b/pkg/otlp/metrics/mixed_metrics_test.go
@@ -32,13 +32,11 @@ func TestMapMetrics(t *testing.T) {
 			expectedUnsupportedAggregationTemporality: 2,
 		},
 		{
-			name:     "resource-attributes-as-tags",
-			otlpfile: "testdata/otlpdata/mixed/simple.json",
-			ddogfile: "testdata/datadogdata/mixed/simple_res-tags.json",
-			options: []TranslatorOption{
-				WithResourceAttributesAsTags(),
-			},
-			expectedUnknownMetricType:                 1,
+			name:                      "resource-attributes-as-tags",
+			otlpfile:                  "testdata/otlpdata/mixed/simple.json",
+			ddogfile:                  "testdata/datadogdata/mixed/simple_res-tags.json",
+			options:                   []TranslatorOption{},
+			expectedUnknownMetricType: 1,
 			expectedUnsupportedAggregationTemporality: 2,
 		},
 		{
@@ -87,7 +85,6 @@ func TestMapMetrics(t *testing.T) {
 			otlpfile: "testdata/otlpdata/mixed/simple.json",
 			ddogfile: "testdata/datadogdata/mixed/simple_res-ilmd-tags.json",
 			options: []TranslatorOption{
-				WithResourceAttributesAsTags(),
 				WithInstrumentationLibraryMetadataAsTags(),
 			},
 			expectedUnknownMetricType:                 1,
@@ -99,7 +96,6 @@ func TestMapMetrics(t *testing.T) {
 			ddogfile: "testdata/datadogdata/mixed/simple_cs-both-tags.json",
 			options: []TranslatorOption{
 				WithHistogramAggregations(),
-				WithResourceAttributesAsTags(),
 				WithInstrumentationLibraryMetadataAsTags(),
 			},
 			expectedUnknownMetricType:                 1,
@@ -111,7 +107,6 @@ func TestMapMetrics(t *testing.T) {
 			ddogfile: "testdata/datadogdata/mixed/simple_all.json",
 			options: []TranslatorOption{
 				WithHistogramAggregations(),
-				WithResourceAttributesAsTags(),
 				WithInstrumentationLibraryMetadataAsTags(),
 				WithInstrumentationScopeMetadataAsTags(),
 			},


### PR DESCRIPTION
### What does this PR do?

Remove `ResourceAttributesAsTags` from translator config as this gets called directly via metrics exporter config in:
- Agent: https://github.com/DataDog/datadog-agent/blob/main/comp/otelcol/otlp/internal/serializerexporter/factory.go#L60
- DatadogExporter: https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/exporter/datadogexporter/factory.go#L298

### Motivation

This was flagged in: https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/29702 and #156.


