### PR TITLE
[pkg/otlp/logs] Ignore resource attributes semantic conventions outside of the resource

### DIFF
--- a/.chloggen/mx-psi_resource-attributes-instead-of-resource.yaml
+++ b/.chloggen/mx-psi_resource-attributes-instead-of-resource.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component (e.g. pkg/quantile)
+component: pkg/otlp/logs
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Ignore service.name and host attributes at the log record level, only honor them if in the resource attributes.
+
+# The PR related to this change
+issues: [223]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/pkg/otlp/logs/logs_translator.go
+++ b/pkg/otlp/logs/logs_translator.go
@@ -198,22 +198,8 @@ func extractHostNameAndServiceName(resourceAttrs pcommon.Map, logAttrs pcommon.M
 	if src, ok := attributes.SourceFromAttrs(resourceAttrs); ok && src.Kind == source.HostnameKind {
 		host = src.Identifier
 	}
-	// hostName is blank from resource
-	// we need to derive from log attributes
-	if host == "" {
-		if src, ok := attributes.SourceFromAttrs(logAttrs); ok && src.Kind == source.HostnameKind {
-			host = src.Identifier
-		}
-	}
 	if s, ok := resourceAttrs.Get(conventions.AttributeServiceName); ok {
 		service = s.AsString()
-	}
-	// serviceName is blank from resource
-	// we need to derive from log attributes
-	if service == "" {
-		if s, ok := logAttrs.Get(conventions.AttributeServiceName); ok {
-			service = s.AsString()
-		}
 	}
 	return host, service
 }

--- a/pkg/otlp/logs/logs_translator_test.go
+++ b/pkg/otlp/logs/logs_translator_test.go
@@ -130,17 +130,17 @@ func TestTransform(t *testing.T) {
 				lr: func() plog.LogRecord {
 					l := plog.NewLogRecord()
 					l.Attributes().PutStr("app", "test")
-					l.Attributes().PutStr(conventions.AttributeServiceName, "otlp_col")
 					l.SetSeverityNumber(5)
 					return l
 				}(),
 				res: func() pcommon.Resource {
 					r := pcommon.NewResource()
+					r.Attributes().PutStr(conventions.AttributeServiceName, "otlp_col")
 					return r
 				}(),
 			},
 			want: datadogV2.HTTPLogItem{
-				Ddtags:  datadog.PtrString(""),
+				Ddtags:  datadog.PtrString("service:otlp_col"),
 				Message: *datadog.PtrString(""),
 				Service: datadog.PtrString("otlp_col"),
 				AdditionalProperties: map[string]string{
@@ -159,17 +159,17 @@ func TestTransform(t *testing.T) {
 					l.Attributes().PutStr("app", "test")
 					l.SetSpanID(spanID)
 					l.SetTraceID(traceID)
-					l.Attributes().PutStr(conventions.AttributeServiceName, "otlp_col")
 					l.SetSeverityNumber(5)
 					return l
 				}(),
 				res: func() pcommon.Resource {
 					r := pcommon.NewResource()
+					r.Attributes().PutStr(conventions.AttributeServiceName, "otlp_col")
 					return r
 				}(),
 			},
 			want: datadogV2.HTTPLogItem{
-				Ddtags:  datadog.PtrString(""),
+				Ddtags:  datadog.PtrString("service:otlp_col"),
 				Message: *datadog.PtrString(""),
 				Service: datadog.PtrString("otlp_col"),
 				AdditionalProperties: map[string]string{
@@ -192,17 +192,17 @@ func TestTransform(t *testing.T) {
 					l.Attributes().PutStr("app", "test")
 					l.Attributes().PutStr("spanid", "2e26da881214cd7c")
 					l.Attributes().PutStr("traceid", "437ab4d83468c540bb0f3398a39faa59")
-					l.Attributes().PutStr(conventions.AttributeServiceName, "otlp_col")
 					l.SetSeverityNumber(5)
 					return l
 				}(),
 				res: func() pcommon.Resource {
 					r := pcommon.NewResource()
+					r.Attributes().PutStr(conventions.AttributeServiceName, "otlp_col")
 					return r
 				}(),
 			},
 			want: datadogV2.HTTPLogItem{
-				Ddtags:  datadog.PtrString(""),
+				Ddtags:  datadog.PtrString("service:otlp_col"),
 				Message: *datadog.PtrString(""),
 				Service: datadog.PtrString("otlp_col"),
 				AdditionalProperties: map[string]string{
@@ -225,17 +225,17 @@ func TestTransform(t *testing.T) {
 					l.Attributes().PutStr("app", "test")
 					l.Attributes().PutStr("span_id", "2e26da881214cd7c")
 					l.Attributes().PutStr("trace_id", "740112b325075be8c80a48de336ebc67")
-					l.Attributes().PutStr(conventions.AttributeServiceName, "otlp_col")
 					l.SetSeverityNumber(5)
 					return l
 				}(),
 				res: func() pcommon.Resource {
 					r := pcommon.NewResource()
+					r.Attributes().PutStr(conventions.AttributeServiceName, "otlp_col")
 					return r
 				}(),
 			},
 			want: datadogV2.HTTPLogItem{
-				Ddtags:  datadog.PtrString(""),
+				Ddtags:  datadog.PtrString("service:otlp_col"),
 				Message: *datadog.PtrString(""),
 				Service: datadog.PtrString("otlp_col"),
 				AdditionalProperties: map[string]string{
@@ -258,17 +258,17 @@ func TestTransform(t *testing.T) {
 					l.Attributes().PutStr("app", "test")
 					l.Attributes().PutStr("spanid", "2e26da881214cd7c")
 					l.Attributes().PutStr("traceid", "invalidtraceid")
-					l.Attributes().PutStr(conventions.AttributeServiceName, "otlp_col")
 					l.SetSeverityNumber(5)
 					return l
 				}(),
 				res: func() pcommon.Resource {
 					r := pcommon.NewResource()
+					r.Attributes().PutStr(conventions.AttributeServiceName, "otlp_col")
 					return r
 				}(),
 			},
 			want: datadogV2.HTTPLogItem{
-				Ddtags:  datadog.PtrString(""),
+				Ddtags:  datadog.PtrString("service:otlp_col"),
 				Message: *datadog.PtrString(""),
 				Service: datadog.PtrString("otlp_col"),
 				AdditionalProperties: map[string]string{
@@ -290,18 +290,18 @@ func TestTransform(t *testing.T) {
 					l.Attributes().PutStr("app", "test")
 					l.SetSpanID(spanID)
 					l.SetTraceID(traceID)
-					l.Attributes().PutStr(conventions.AttributeServiceName, "otlp_col")
 					l.SetSeverityText("alert")
 					l.SetSeverityNumber(5)
 					return l
 				}(),
 				res: func() pcommon.Resource {
 					r := pcommon.NewResource()
+					r.Attributes().PutStr(conventions.AttributeServiceName, "otlp_col")
 					return r
 				}(),
 			},
 			want: datadogV2.HTTPLogItem{
-				Ddtags:  datadog.PtrString(""),
+				Ddtags:  datadog.PtrString("service:otlp_col"),
 				Message: *datadog.PtrString(""),
 				Service: datadog.PtrString("otlp_col"),
 				AdditionalProperties: map[string]string{
@@ -325,18 +325,18 @@ func TestTransform(t *testing.T) {
 					l.Attributes().PutStr("app", "test")
 					l.SetSpanID(spanID)
 					l.SetTraceID(traceID)
-					l.Attributes().PutStr(conventions.AttributeServiceName, "otlp_col")
 					l.SetSeverityNumber(13)
 					l.Body().SetStr("This is log")
 					return l
 				}(),
 				res: func() pcommon.Resource {
 					r := pcommon.NewResource()
+					r.Attributes().PutStr(conventions.AttributeServiceName, "otlp_col")
 					return r
 				}(),
 			},
 			want: datadogV2.HTTPLogItem{
-				Ddtags:  datadog.PtrString(""),
+				Ddtags:  datadog.PtrString("service:otlp_col"),
 				Message: *datadog.PtrString(""),
 				Service: datadog.PtrString("otlp_col"),
 				AdditionalProperties: map[string]string{
@@ -360,18 +360,18 @@ func TestTransform(t *testing.T) {
 					l.Attributes().PutStr("app", "test")
 					l.SetSpanID(spanID)
 					l.SetTraceID(traceID)
-					l.Attributes().PutStr(conventions.AttributeServiceName, "otlp_col")
 					l.Attributes().PutStr("level", "error")
 					l.Body().SetStr("This is log")
 					return l
 				}(),
 				res: func() pcommon.Resource {
 					r := pcommon.NewResource()
+					r.Attributes().PutStr(conventions.AttributeServiceName, "otlp_col")
 					return r
 				}(),
 			},
 			want: datadogV2.HTTPLogItem{
-				Ddtags:  datadog.PtrString(""),
+				Ddtags:  datadog.PtrString("service:otlp_col"),
 				Message: *datadog.PtrString(""),
 				Service: datadog.PtrString("otlp_col"),
 				AdditionalProperties: map[string]string{


### PR DESCRIPTION
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Ignores `service.name` and hostname-related resource attributes outside of the resource level for logs.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

These semantic conventions are for resource attributes only, recognizing them at the log level is not in the specification and thus can be argued to be incorrect.