### PR TITLE
Rename metric to datadog.otlp_translator.resources.missing_source

### DIFF
--- a/.chloggen/mx-psi_rename-to-resource.yaml
+++ b/.chloggen/mx-psi_rename-to-resource.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component (e.g. pkg/quantile)
+component: pkg/otlp/metrics
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Rename `datadog.otlp_translator.metrics.missing_source` to `datadog.otlp_translator.resources.missing_source` with `signal:metrics` attribute.
+
+# The PR related to this change
+issues: [229]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/pkg/otlp/metrics/go.mod
+++ b/pkg/otlp/metrics/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/stretchr/testify v1.8.4
 	go.opentelemetry.io/collector/component v0.91.0
 	go.opentelemetry.io/collector/pdata v1.0.0
+	go.opentelemetry.io/otel v1.21.0
 	go.opentelemetry.io/otel/metric v1.21.0
 	go.opentelemetry.io/otel/sdk/metric v1.21.0
 	go.uber.org/zap v1.26.0
@@ -44,7 +45,6 @@ require (
 	go.opentelemetry.io/collector/confmap v0.91.0 // indirect
 	go.opentelemetry.io/collector/featuregate v1.0.0 // indirect
 	go.opentelemetry.io/collector/semconv v0.91.0 // indirect
-	go.opentelemetry.io/otel v1.21.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.21.0 // indirect
 	go.opentelemetry.io/otel/trace v1.21.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect

--- a/pkg/otlp/metrics/metrics_translator.go
+++ b/pkg/otlp/metrics/metrics_translator.go
@@ -47,7 +47,7 @@ const (
 )
 
 var (
-	signalTypeSet = attribute.NewSet(attribute.String("signal", "logs"))
+	signalTypeSet = attribute.NewSet(attribute.String("signal", "metrics"))
 )
 
 var _ source.Provider = (*noSourceProvider)(nil)

--- a/pkg/otlp/metrics/metrics_translator.go
+++ b/pkg/otlp/metrics/metrics_translator.go
@@ -29,6 +29,7 @@ import (
 	"go.opentelemetry.io/collector/component"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/otel/attribute"
 	otelmetric "go.opentelemetry.io/otel/metric"
 	"go.uber.org/zap"
 	"golang.org/x/exp/slices"
@@ -41,8 +42,12 @@ const (
 	metricName             string = "metric name"
 	errNoBucketsNoSumCount string = "no buckets mode and no send count sum are incompatible"
 
-	meterName               string = "github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/metrics"
-	missingSourceMetricName string = "datadog.otlp_translator.metrics.missing_source"
+	meterName               string = "github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes"
+	missingSourceMetricName string = "datadog.otlp_translator.resources.missing_source"
+)
+
+var (
+	signalTypeSet = attribute.NewSet(attribute.String("signal", "logs"))
 )
 
 var _ source.Provider = (*noSourceProvider)(nil)
@@ -101,7 +106,7 @@ func NewTranslator(set component.TelemetrySettings, options ...TranslatorOption)
 	missingSources, err := meter.Int64Counter(
 		missingSourceMetricName,
 		otelmetric.WithDescription("OTLP metrics that are missing a source (e.g. hostname)"),
-		otelmetric.WithUnit("[metric]"),
+		otelmetric.WithUnit("{resource}"),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("failed to build missing source counter: %w", err)
@@ -678,6 +683,11 @@ func (t *Translator) MapMetrics(ctx context.Context, md pmetric.Metrics, consume
 		if err != nil {
 			return metadata, err
 		}
+		if !hasSource {
+			// Only count metrics if they do not come from the translator itself.
+			t.instruments.missingSources.Add(ctx, 1, otelmetric.WithAttributeSet(signalTypeSet))
+		}
+
 		var host string
 		switch src.Kind {
 		case source.HostnameKind:
@@ -698,11 +708,6 @@ func (t *Translator) MapMetrics(ctx context.Context, md pmetric.Metrics, consume
 		for j := 0; j < ilms.Len(); j++ {
 			ilm := ilms.At(j)
 			metricsArray := ilm.Metrics()
-
-			if !hasSource && ilm.Scope().Name() != meterName {
-				// Only count metrics if they do not come from the translator itself.
-				t.instruments.missingSources.Add(ctx, int64(metricsArray.Len()))
-			}
 
 			var additionalTags []string
 			if t.cfg.InstrumentationScopeMetadataAsTags {

--- a/pkg/otlp/metrics/metrics_translator.go
+++ b/pkg/otlp/metrics/metrics_translator.go
@@ -684,7 +684,6 @@ func (t *Translator) MapMetrics(ctx context.Context, md pmetric.Metrics, consume
 			return metadata, err
 		}
 		if !hasSource {
-			// Only count metrics if they do not come from the translator itself.
 			t.instruments.missingSources.Add(ctx, 1, otelmetric.WithAttributeSet(signalTypeSet))
 		}
 

--- a/pkg/otlp/metrics/metrics_translator.go
+++ b/pkg/otlp/metrics/metrics_translator.go
@@ -105,7 +105,7 @@ func NewTranslator(set component.TelemetrySettings, options ...TranslatorOption)
 	meter := set.MeterProvider.Meter(meterName)
 	missingSources, err := meter.Int64Counter(
 		missingSourceMetricName,
-		otelmetric.WithDescription("OTLP metrics that are missing a source (e.g. hostname)"),
+		otelmetric.WithDescription("OTLP resources that are missing a source (e.g. hostname)"),
 		otelmetric.WithUnit("{resource}"),
 	)
 	if err != nil {

--- a/pkg/otlp/metrics/source_test.go
+++ b/pkg/otlp/metrics/source_test.go
@@ -63,7 +63,7 @@ func TestInternalTelemetryMetrics(t *testing.T) {
 			name:               "simple",
 			otlpfile:           "testdata/otlpdata/source/simple.json",
 			ddogfile:           "testdata/datadogdata/source/simple.json",
-			expectedNumMissing: 4,
+			expectedNumMissing: 1,
 		},
 	}
 


### PR DESCRIPTION
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Renames metric to `datadog.otlp_translator.resources.missing_source` as in #222.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->


This PR is to ensure that we don't have to make breaking changes on the metric while the refactor proposed in #222 is happening.
