### PR TITLE
[pkg/inframetadata] Add support for host tags

### DIFF
--- a/.chloggen/host-tags-auto.yaml
+++ b/.chloggen/host-tags-auto.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component (e.g. pkg/quantile)
+component: pkg/inframetadata
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Resource attributes for deployment environment and cluster name are now automatically added as host tags for the host associated with the resource. "
+
+# The PR related to this change
+issues: [233]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/mx-psi_host-tags.yaml
+++ b/.chloggen/mx-psi_host-tags.yaml
@@ -1,0 +1,17 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component (e.g. pkg/quantile)
+component: pkg/inframetadata
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Resource attributes prefixed by `datadog.host.tag.` are now added as host tags for the host associated with the resource. "
+
+# The PR related to this change
+issues: [233]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: | 
+  For example, a resource attribute `datadog.host.tag.foo: bar` will be added as a host tag `foo:bar` for the host associated with the resource.

--- a/LICENSE-3rdparty.csv
+++ b/LICENSE-3rdparty.csv
@@ -409,6 +409,7 @@ pkg/inframetadata,go.opentelemetry.io/collector/pdata/internal/otlp,Apache-2.0,C
 pkg/inframetadata,go.opentelemetry.io/collector/pdata/pcommon,Apache-2.0,Copyright The OpenTelemetry Authors
 pkg/inframetadata,go.opentelemetry.io/collector/pdata/pmetric,Apache-2.0,Copyright The OpenTelemetry Authors
 pkg/inframetadata,go.opentelemetry.io/collector/semconv/v1.18.0,Apache-2.0,Copyright The OpenTelemetry Authors
+pkg/inframetadata,go.opentelemetry.io/collector/semconv/v1.21.0,Apache-2.0,Copyright The OpenTelemetry Authors
 pkg/inframetadata,go.opentelemetry.io/collector/semconv/v1.6.1,Apache-2.0,Copyright The OpenTelemetry Authors
 pkg/inframetadata,go.opentelemetry.io/otel/attribute,Apache-2.0,Copyright The OpenTelemetry Authors
 pkg/inframetadata,go.opentelemetry.io/otel/codes,Apache-2.0,Copyright The OpenTelemetry Authors

--- a/pkg/inframetadata/internal/hostmap/errors.go
+++ b/pkg/inframetadata/internal/hostmap/errors.go
@@ -1,0 +1,32 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+package hostmap
+
+import (
+	"fmt"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+)
+
+var _ error = mismatchedTypeErr{}
+
+type mismatchedTypeErr struct {
+	name         string
+	actualType   pcommon.ValueType
+	expectedType pcommon.ValueType
+}
+
+func mismatchErr(name string, actualType, expectedType pcommon.ValueType) error {
+	return mismatchedTypeErr{
+		name:         name,
+		actualType:   actualType,
+		expectedType: expectedType,
+	}
+}
+
+func (e mismatchedTypeErr) Error() string {
+	return fmt.Sprintf("%q has type %q, expected type %q instead", e.name, e.actualType, e.expectedType)
+}

--- a/pkg/inframetadata/internal/hostmap/hostmap.go
+++ b/pkg/inframetadata/internal/hostmap/hostmap.go
@@ -7,7 +7,6 @@ package hostmap
 
 import (
 	"fmt"
-	"slices"
 	"strings"
 	"sync"
 
@@ -175,6 +174,22 @@ func (m *HostMap) newOrFetchHostMetadata(host string) (payload.HostMetadata, boo
 	return md, ok
 }
 
+// equalSlices checks if two slices are equal.
+// Vendored from https://cs.opensource.google/go/go/+/refs/tags/go1.21.5:src/slices/slices.go;l=18
+// To preserve compatibility with Go 1.20.
+// Can be replaced by slices.Equal when we drop support for Go 1.20.
+func equalSlices[S ~[]E, E comparable](s1, s2 S) bool {
+	if len(s1) != len(s2) {
+		return false
+	}
+	for i := range s1 {
+		if s1[i] != s2[i] {
+			return false
+		}
+	}
+	return true
+}
+
 // Update the information about a given host by providing a resource.
 // The function reports:
 //   - Whether the information about the `host` has changed
@@ -202,7 +217,7 @@ func (m *HostMap) Update(host string, res pcommon.Resource) (changed bool, md pa
 		err = multierr.Append(err, tagsErr)
 	} else {
 		old := md.Tags.OTel
-		changed = changed || !slices.Equal[[]string](old, tags)
+		changed = changed || !equalSlices[[]string](old, tags)
 		md.Tags.OTel = tags
 	}
 

--- a/pkg/inframetadata/internal/hostmap/hostmap_test.go
+++ b/pkg/inframetadata/internal/hostmap/hostmap_test.go
@@ -71,7 +71,7 @@ func TestStrSliceField(t *testing.T) {
 			key:         "host.ip",
 			expected:    nil,
 			expectedOk:  false,
-			expectedErr: "host.ip[1] has type \"Bool\", expected type \"Str\" instead",
+			expectedErr: "\"host.ip[1]\" has type \"Bool\", expected type \"Str\" instead",
 		},
 	}
 
@@ -147,23 +147,25 @@ func TestUpdate(t *testing.T) {
 		{
 			hostname: "host-1-hostid",
 			attributes: map[string]any{
-				conventions.AttributeCloudProvider: conventions.AttributeCloudProviderAWS,
-				conventions.AttributeHostID:        "host-1-hostid",
-				conventions.AttributeHostName:      "host-1-hostname",
-				conventions.AttributeOSDescription: "Fedora Linux",
-				conventions.AttributeOSType:        conventions.AttributeOSTypeLinux,
-				conventions.AttributeHostArch:      conventions.AttributeHostArchAMD64,
-				attributeKernelName:                "GNU/Linux",
-				attributeKernelRelease:             "5.19.0-43-generic",
-				attributeKernelVersion:             "#44~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC Mon May 22 13:39:36 UTC 2",
-				attributeHostCPUVendorID:           "GenuineIntel",
-				attributeHostCPUFamily:             6,
-				attributeHostCPUModelID:            10,
-				attributeHostCPUModelName:          "11th Gen Intel(R) Core(TM) i7-1185G7 @ 3.00GHz",
-				attributeHostCPUStepping:           1,
-				attributeHostCPUCacheL2Size:        12288000,
-				attributeHostIP:                    []any{"192.168.1.140", "fe80::abc2:4a28:737a:609e"},
-				attributeHostMAC:                   []any{"AC-DE-48-23-45-67", "AC-DE-48-23-45-67-01-9F"},
+				conventions.AttributeCloudProvider:         conventions.AttributeCloudProviderAWS,
+				conventions.AttributeHostID:                "host-1-hostid",
+				conventions.AttributeHostName:              "host-1-hostname",
+				conventions.AttributeOSDescription:         "Fedora Linux",
+				conventions.AttributeOSType:                conventions.AttributeOSTypeLinux,
+				conventions.AttributeHostArch:              conventions.AttributeHostArchAMD64,
+				attributeKernelName:                        "GNU/Linux",
+				attributeKernelRelease:                     "5.19.0-43-generic",
+				attributeKernelVersion:                     "#44~22.04.1-Ubuntu SMP PREEMPT_DYNAMIC Mon May 22 13:39:36 UTC 2",
+				attributeHostCPUVendorID:                   "GenuineIntel",
+				attributeHostCPUFamily:                     6,
+				attributeHostCPUModelID:                    10,
+				attributeHostCPUModelName:                  "11th Gen Intel(R) Core(TM) i7-1185G7 @ 3.00GHz",
+				attributeHostCPUStepping:                   1,
+				attributeHostCPUCacheL2Size:                12288000,
+				attributeHostIP:                            []any{"192.168.1.140", "fe80::abc2:4a28:737a:609e"},
+				attributeHostMAC:                           []any{"AC-DE-48-23-45-67", "AC-DE-48-23-45-67-01-9F"},
+				"datadog.host.tag.foo":                     "bar",
+				conventions.AttributeDeploymentEnvironment: "prod",
 			},
 			metric:          BuildMetric[int64](metricSystemCPUPhysicalCount, 32),
 			expectedChanged: false,
@@ -172,10 +174,12 @@ func TestUpdate(t *testing.T) {
 			// Same as #1, but missing some attributes
 			hostname: "host-1-hostid",
 			attributes: map[string]any{
-				conventions.AttributeCloudProvider: conventions.AttributeCloudProviderAWS,
-				conventions.AttributeHostID:        "host-1-hostid",
-				conventions.AttributeHostName:      "host-1-hostname",
-				conventions.AttributeOSDescription: "Fedora Linux",
+				conventions.AttributeCloudProvider:         conventions.AttributeCloudProviderAWS,
+				conventions.AttributeHostID:                "host-1-hostid",
+				conventions.AttributeHostName:              "host-1-hostname",
+				conventions.AttributeOSDescription:         "Fedora Linux",
+				"datadog.host.tag.foo":                     "bar",
+				conventions.AttributeDeploymentEnvironment: "prod",
 			},
 			metric:          BuildMetric[float64](metricSystemCPUFrequency, 400_000_005.5),
 			expectedChanged: false,
@@ -184,14 +188,16 @@ func TestUpdate(t *testing.T) {
 			// Same as #1 but wrong type and an update
 			hostname: "host-1-hostid",
 			attributes: map[string]any{
-				conventions.AttributeCloudProvider: conventions.AttributeCloudProviderAWS,
-				conventions.AttributeHostID:        "host-1-hostid",
-				conventions.AttributeHostName:      "host-1-hostname",
-				conventions.AttributeOSDescription: true, // wrong type
-				conventions.AttributeHostArch:      conventions.AttributeHostArchAMD64,
-				attributeKernelName:                "GNU/Linux",
-				attributeKernelRelease:             "5.19.0-43-generic",
-				attributeKernelVersion:             "#82~18.04.1-Ubuntu SMP Fri Apr 16 15:10:02 UTC 2021", // changed
+				conventions.AttributeCloudProvider:         conventions.AttributeCloudProviderAWS,
+				conventions.AttributeHostID:                "host-1-hostid",
+				conventions.AttributeHostName:              "host-1-hostname",
+				conventions.AttributeOSDescription:         true, // wrong type
+				conventions.AttributeHostArch:              conventions.AttributeHostArchAMD64,
+				attributeKernelName:                        "GNU/Linux",
+				attributeKernelRelease:                     "5.19.0-43-generic",
+				attributeKernelVersion:                     "#82~18.04.1-Ubuntu SMP Fri Apr 16 15:10:02 UTC 2021", // changed
+				"datadog.host.tag.foo":                     "baz",                                                 // changed
+				conventions.AttributeDeploymentEnvironment: "prod",
 			},
 			expectedChanged: true,
 			expectedErrs:    []string{"\"os.description\" has type \"Bool\", expected type \"Str\" instead"},
@@ -200,13 +206,15 @@ func TestUpdate(t *testing.T) {
 			// Same as #1 but wrong type in two places and no update
 			hostname: "host-1-hostid",
 			attributes: map[string]any{
-				conventions.AttributeCloudProvider: conventions.AttributeCloudProviderAWS,
-				conventions.AttributeHostID:        "host-1-hostid",
-				conventions.AttributeHostName:      "host-1-hostname",
-				conventions.AttributeOSDescription: true, // wrong type
-				conventions.AttributeHostArch:      conventions.AttributeHostArchAMD64,
-				attributeKernelName:                false, // wrong type
-				attributeKernelRelease:             "5.19.0-43-generic",
+				conventions.AttributeCloudProvider:         conventions.AttributeCloudProviderAWS,
+				conventions.AttributeHostID:                "host-1-hostid",
+				conventions.AttributeHostName:              "host-1-hostname",
+				conventions.AttributeOSDescription:         true, // wrong type
+				conventions.AttributeHostArch:              conventions.AttributeHostArchAMD64,
+				attributeKernelName:                        false, // wrong type
+				attributeKernelRelease:                     "5.19.0-43-generic",
+				"datadog.host.tag.foo":                     "baz",
+				conventions.AttributeDeploymentEnvironment: "prod",
 			},
 			expectedChanged: false,
 			expectedErrs: []string{
@@ -256,7 +264,7 @@ func TestUpdate(t *testing.T) {
 			EC2Hostname: "host-1-hostname",
 			Hostname:    "host-1-hostid",
 		})
-		assert.Equal(t, md.Tags, &payload.HostTags{})
+		assert.ElementsMatch(t, md.Tags.OTel, []string{"foo:baz", "env:prod"})
 		assert.Equal(t, md.Payload.Gohai.Gohai.Platform, map[string]string{
 			"hostname":                    "host-1-hostid",
 			fieldPlatformOS:               "Fedora Linux",

--- a/pkg/inframetadata/internal/hostmap/tags.go
+++ b/pkg/inframetadata/internal/hostmap/tags.go
@@ -1,0 +1,59 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+package hostmap
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	conventions "go.opentelemetry.io/collector/semconv/v1.21.0"
+	"go.uber.org/multierr"
+)
+
+const hostTagPrefix = "datadog.host.tag."
+
+var hostTagMapping = map[string]string{
+	conventions.AttributeDeploymentEnvironment: "env",
+	conventions.AttributeK8SClusterName:        "cluster_name",
+}
+
+// assertStringValue returns the string value of the given value, or an error if the value is not a string.
+func assertStringValue(name string, v pcommon.Value) (string, error) {
+	if v.Type() != pcommon.ValueTypeStr {
+		return "", mismatchErr(name, v.Type(), pcommon.ValueTypeStr)
+	}
+	return v.Str(), nil
+}
+
+// getHostTags returns a slice of tags from the given map.
+func getHostTags(m pcommon.Map) ([]string, error) {
+	var tags []string
+	var err error
+	m.Range(func(k string, v pcommon.Value) bool {
+		if strings.HasPrefix(k, hostTagPrefix) { // User-defined tags
+			if str, err2 := assertStringValue(k, v); err2 != nil {
+				err = multierr.Append(err, err2)
+			} else if str == "" {
+				err = multierr.Append(err, fmt.Errorf("attribute %q has empty string value, expected non-empty string", k))
+			} else {
+				tags = append(tags, k[len(hostTagPrefix):]+":"+str)
+			}
+		} else if mappedKey, ok := hostTagMapping[k]; ok { // Well-known tags
+			if str, err2 := assertStringValue(k, v); err2 != nil {
+				err = multierr.Append(err, err2)
+			} else {
+				tags = append(tags, mappedKey+":"+str)
+			}
+		}
+		return true
+	})
+
+	// Allow for comparison of tags
+	sort.Strings(tags)
+	return tags, err
+}


### PR DESCRIPTION
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

- Resource attributes prefixed by `datadog.host.tag.` are now added as host tags for the host associated with the resource.
- Resource attributes for deployment environment and cluster name are now automatically added as host tags for the host associated with the resource.

Edge cases:

- If the type of a `datadog.host.tag.` prefixed attribute is not string, en error is raised
- If a `datadog.host.tag.` attribute has an empty string as a value, an error is raised
- Host tags are not updated per-tag but rather as a whole. For example, if a payload has `datadog.host.tag.foo -> bar` and `datadog.host.tag.baz -> qux` as resource attributes, and the next one only has `datadog.host.tag.foo -> bar`, the final payload after these transformations will only have `foo:bar` and **NOT** `baz:qux`. This is different from other attributes, but allows for removing host tags.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Allow users to add host tags for remote hosts.
