### PR TITLE
[pkg/otlp/metrics][OTEL-1652] Support empty histograms

### DIFF
--- a/.chloggen/mx-psi_empty-histograms.yaml
+++ b/.chloggen/mx-psi_empty-histograms.yaml
@@ -1,0 +1,17 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component (e.g. pkg/quantile)
+component: pkg/otlp/metric
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fixes a bug where empty histograms were not being sent to the backend in the distributions mode.
+
+# The PR related to this change
+issues: [252]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: | 
+  - Empty histograms are now mapped as if they had a single (min, max) bucket.

--- a/pkg/otlp/metrics/histograms_test.go
+++ b/pkg/otlp/metrics/histograms_test.go
@@ -77,6 +77,38 @@ func TestDeltaHistogramTranslatorOptions(t *testing.T) {
 			},
 		},
 		{
+			name:     "empty-delta-no-min-max",
+			otlpfile: "testdata/otlpdata/histogram/empty-delta-no-min-max.json",
+			ddogfile: "testdata/datadogdata/histogram/empty-delta-no-min-max.json",
+			options: []TranslatorOption{
+				WithHistogramMode(HistogramModeDistributions),
+			},
+		},
+		{
+			name:     "empty-delta-with-min-max",
+			otlpfile: "testdata/otlpdata/histogram/empty-delta-with-min-max.json",
+			ddogfile: "testdata/datadogdata/histogram/empty-delta-with-min-max.json",
+			options: []TranslatorOption{
+				WithHistogramMode(HistogramModeDistributions),
+			},
+		},
+		{
+			name:     "single-bucket-delta-no-min-max",
+			otlpfile: "testdata/otlpdata/histogram/single-bucket-delta-no-min-max.json",
+			ddogfile: "testdata/datadogdata/histogram/single-bucket-delta-no-min-max.json",
+			options: []TranslatorOption{
+				WithHistogramMode(HistogramModeDistributions),
+			},
+		},
+		{
+			name:     "single-bucket-delta-with-min-max",
+			otlpfile: "testdata/otlpdata/histogram/single-bucket-delta-with-min-max.json",
+			ddogfile: "testdata/datadogdata/histogram/single-bucket-delta-with-min-max.json",
+			options: []TranslatorOption{
+				WithHistogramMode(HistogramModeDistributions),
+			},
+		},
+		{
 			name: "no-count-sum-no-buckets",
 			options: []TranslatorOption{
 				WithHistogramMode(HistogramModeNoBuckets),

--- a/pkg/otlp/metrics/metrics_translator.go
+++ b/pkg/otlp/metrics/metrics_translator.go
@@ -245,15 +245,15 @@ func (t *Translator) mapNumberMonotonicMetrics(
 	}
 }
 
-func getBounds(p pmetric.HistogramDataPoint, idx int) (lowerBound float64, upperBound float64) {
+func getBounds(explicitBounds []float64, idx int) (lowerBound float64, upperBound float64) {
 	// See https://github.com/open-telemetry/opentelemetry-proto/blob/v0.10.0/opentelemetry/proto/metrics/v1/metrics.proto#L427-L439
 	lowerBound = math.Inf(-1)
 	upperBound = math.Inf(1)
 	if idx > 0 {
-		lowerBound = p.ExplicitBounds().At(idx - 1)
+		lowerBound = explicitBounds[idx-1]
 	}
-	if idx < p.ExplicitBounds().Len() {
-		upperBound = p.ExplicitBounds().At(idx)
+	if idx < len(explicitBounds) {
+		upperBound = explicitBounds[idx]
 	}
 	return
 }
@@ -288,6 +288,9 @@ func (t *Translator) getSketchBuckets(
 	ts := uint64(p.Timestamp())
 	as := &quantile.Agent{}
 
+	bucketCounts := p.BucketCounts().AsRaw()
+	explicitBounds := p.ExplicitBounds().AsRaw()
+
 	// After the loop,
 	// - minBound contains the lower bound of the lowest nonzero bucket,
 	// - maxBound contains the upper bound of the highest nonzero bucket
@@ -295,8 +298,8 @@ func (t *Translator) getSketchBuckets(
 	//   there was at least a nonzero bucket.
 	var minBound, maxBound float64
 	var minBoundSet bool
-	for j := 0; j < p.BucketCounts().Len(); j++ {
-		lowerBound, upperBound := getBounds(p, j)
+	for j := 0; j < len(bucketCounts); j++ {
+		lowerBound, upperBound := getBounds(explicitBounds, j)
 		originalLowerBound, originalUpperBound := lowerBound, upperBound
 
 		// Compute temporary bucketTags to have unique keys in the t.prevPts cache for each bucket
@@ -316,7 +319,7 @@ func (t *Translator) getSketchBuckets(
 			lowerBound = upperBound
 		}
 
-		count := p.BucketCounts().At(j)
+		count := bucketCounts[j]
 		var nonZeroBucket bool
 		if delta {
 			nonZeroBucket = count > 0
@@ -388,7 +391,7 @@ func (t *Translator) getLegacyBuckets(
 	// https://github.com/DataDog/integrations-core/blob/7.30.1/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/transformers/histogram.py
 	baseBucketDims := pointDims.WithSuffix("bucket")
 	for idx := 0; idx < p.BucketCounts().Len(); idx++ {
-		lowerBound, upperBound := getBounds(p, idx)
+		lowerBound, upperBound := getBounds(p.ExplicitBounds().AsRaw(), idx)
 		bucketDims := baseBucketDims.AddTags(
 			fmt.Sprintf("lower_bound:%s", formatFloat(lowerBound)),
 			fmt.Sprintf("upper_bound:%s", formatFloat(upperBound)),

--- a/pkg/otlp/metrics/metrics_translator.go
+++ b/pkg/otlp/metrics/metrics_translator.go
@@ -245,15 +245,15 @@ func (t *Translator) mapNumberMonotonicMetrics(
 	}
 }
 
-func getBounds(explicitBounds []float64, idx int) (lowerBound float64, upperBound float64) {
+func getBounds(explicitBounds pcommon.Float64Slice, idx int) (lowerBound float64, upperBound float64) {
 	// See https://github.com/open-telemetry/opentelemetry-proto/blob/v0.10.0/opentelemetry/proto/metrics/v1/metrics.proto#L427-L439
 	lowerBound = math.Inf(-1)
 	upperBound = math.Inf(1)
 	if idx > 0 {
-		lowerBound = explicitBounds[idx-1]
+		lowerBound = explicitBounds.At(idx - 1)
 	}
-	if idx < len(explicitBounds) {
-		upperBound = explicitBounds[idx]
+	if idx < explicitBounds.Len() {
+		upperBound = explicitBounds.At(idx)
 	}
 	return
 }
@@ -288,8 +288,30 @@ func (t *Translator) getSketchBuckets(
 	ts := uint64(p.Timestamp())
 	as := &quantile.Agent{}
 
-	bucketCounts := p.BucketCounts().AsRaw()
-	explicitBounds := p.ExplicitBounds().AsRaw()
+	bucketCounts := p.BucketCounts()
+	explicitBounds := p.ExplicitBounds()
+	// From the spec (https://github.com/open-telemetry/opentelemetry-specification/blob/v1.29.0/specification/metrics/data-model.md#histogram):
+	// > A Histogram without buckets conveys a population in terms of only the sum and count,
+	// > and may be interpreted as a histogram with single bucket covering (-Inf, +Inf).
+	if bucketCounts.Len() == 0 && histInfo.ok {
+		bucketCounts = pcommon.NewUInt64Slice()
+		explicitBounds = pcommon.NewFloat64Slice()
+
+		if histInfo.hasMinFromLastTimeWindow {
+			// Add an empty bucket from -inf to min.
+			bucketCounts.Append(0)
+			explicitBounds.Append(p.Min())
+		}
+
+		// Add a single bucket with the total histogram count to the sketch.
+		bucketCounts.Append(histInfo.count)
+
+		if histInfo.hasMaxFromLastTimeWindow {
+			// Add an empty bucket from max to +inf.
+			bucketCounts.Append(0)
+			explicitBounds.Append(p.Max())
+		}
+	}
 
 	// After the loop,
 	// - minBound contains the lower bound of the lowest nonzero bucket,
@@ -298,7 +320,7 @@ func (t *Translator) getSketchBuckets(
 	//   there was at least a nonzero bucket.
 	var minBound, maxBound float64
 	var minBoundSet bool
-	for j := 0; j < len(bucketCounts); j++ {
+	for j := 0; j < bucketCounts.Len(); j++ {
 		lowerBound, upperBound := getBounds(explicitBounds, j)
 		originalLowerBound, originalUpperBound := lowerBound, upperBound
 
@@ -319,7 +341,7 @@ func (t *Translator) getSketchBuckets(
 			lowerBound = upperBound
 		}
 
-		count := bucketCounts[j]
+		count := bucketCounts.At(j)
 		var nonZeroBucket bool
 		if delta {
 			nonZeroBucket = count > 0
@@ -391,7 +413,7 @@ func (t *Translator) getLegacyBuckets(
 	// https://github.com/DataDog/integrations-core/blob/7.30.1/datadog_checks_base/datadog_checks/base/checks/openmetrics/v2/transformers/histogram.py
 	baseBucketDims := pointDims.WithSuffix("bucket")
 	for idx := 0; idx < p.BucketCounts().Len(); idx++ {
-		lowerBound, upperBound := getBounds(p.ExplicitBounds().AsRaw(), idx)
+		lowerBound, upperBound := getBounds(p.ExplicitBounds(), idx)
 		bucketDims := baseBucketDims.AddTags(
 			fmt.Sprintf("lower_bound:%s", formatFloat(lowerBound)),
 			fmt.Sprintf("upper_bound:%s", formatFloat(upperBound)),

--- a/pkg/otlp/metrics/testdata/datadogdata/histogram/empty-delta-no-min-max.json
+++ b/pkg/otlp/metrics/testdata/datadogdata/histogram/empty-delta-no-min-max.json
@@ -1,0 +1,30 @@
+{
+  "Sketches": [
+    {
+      "Name": "doubleHist.empty.test",
+      "Tags": [
+        "attribute_tag:attribute_value"
+      ],
+      "Host": "hostname",
+      "OriginID": "",
+      "OriginProduct": 10,
+      "OriginCategory": 17,
+      "OriginService": 0,
+      "Timestamp": 1667560641226420924,
+      "Summary": {
+        "Min": -9.941854089121368e-10,
+        "Max": -9.941854089121368e-10,
+        "Sum": 3.141592653589793,
+        "Avg": 0.15707963267948966,
+        "Cnt": 20
+      },
+      "Keys": [
+        -1
+      ],
+      "Counts": [
+        20
+      ]
+    }
+  ],
+  "TimeSeries": null
+}

--- a/pkg/otlp/metrics/testdata/datadogdata/histogram/empty-delta-with-min-max.json
+++ b/pkg/otlp/metrics/testdata/datadogdata/histogram/empty-delta-with-min-max.json
@@ -1,0 +1,30 @@
+{
+  "Sketches": [
+    {
+      "Name": "doubleHist.empty.minmax.test",
+      "Tags": [
+        "attribute_tag:attribute_value"
+      ],
+      "Host": "hostname",
+      "OriginID": "",
+      "OriginProduct": 10,
+      "OriginCategory": 17,
+      "OriginService": 0,
+      "Timestamp": 1667560641226420924,
+      "Summary": {
+        "Min": 100,
+        "Max": 101,
+        "Sum": 3.141592653589793,
+        "Avg": 0.15707963267948966,
+        "Cnt": 20
+      },
+      "Keys": [
+        1635
+      ],
+      "Counts": [
+        20
+      ]
+    }
+  ],
+  "TimeSeries": null
+}

--- a/pkg/otlp/metrics/testdata/datadogdata/histogram/single-bucket-delta-no-min-max.json
+++ b/pkg/otlp/metrics/testdata/datadogdata/histogram/single-bucket-delta-no-min-max.json
@@ -1,0 +1,30 @@
+{
+  "Sketches": [
+    {
+      "Name": "doubleHist.singlebucket.test",
+      "Tags": [
+        "attribute_tag:attribute_value"
+      ],
+      "Host": "hostname",
+      "OriginID": "",
+      "OriginProduct": 10,
+      "OriginCategory": 17,
+      "OriginService": 0,
+      "Timestamp": 1667560641226420924,
+      "Summary": {
+        "Min": -9.941854089121368e-10,
+        "Max": -9.941854089121368e-10,
+        "Sum": 3.141592653589793,
+        "Avg": 0.15707963267948966,
+        "Cnt": 20
+      },
+      "Keys": [
+        -1
+      ],
+      "Counts": [
+        20
+      ]
+    }
+  ],
+  "TimeSeries": null
+}

--- a/pkg/otlp/metrics/testdata/datadogdata/histogram/single-bucket-delta-with-min-max.json
+++ b/pkg/otlp/metrics/testdata/datadogdata/histogram/single-bucket-delta-with-min-max.json
@@ -1,0 +1,30 @@
+{
+  "Sketches": [
+    {
+      "Name": "doubleHist.singlebucket.minmax.test",
+      "Tags": [
+        "attribute_tag:attribute_value"
+      ],
+      "Host": "hostname",
+      "OriginID": "",
+      "OriginProduct": 10,
+      "OriginCategory": 17,
+      "OriginService": 0,
+      "Timestamp": 1667560641226420924,
+      "Summary": {
+        "Min": 100,
+        "Max": 101,
+        "Sum": 3.141592653589793,
+        "Avg": 0.15707963267948966,
+        "Cnt": 20
+      },
+      "Keys": [
+        -1
+      ],
+      "Counts": [
+        20
+      ]
+    }
+  ],
+  "TimeSeries": null
+}

--- a/pkg/otlp/metrics/testdata/otlpdata/histogram/empty-delta-no-min-max.json
+++ b/pkg/otlp/metrics/testdata/otlpdata/histogram/empty-delta-no-min-max.json
@@ -1,0 +1,44 @@
+{
+  "resourceMetrics": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "host.name",
+            "value": {
+              "stringValue": "hostname"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "scope": {},
+          "metrics": [
+            {
+              "name": "doubleHist.empty.test",
+              "histogram": {
+                "dataPoints": [
+                  {
+                    "attributes": [
+                      {
+                        "key": "attribute_tag",
+                        "value": {
+                          "stringValue": "attribute_value"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "1667560641226420924",
+                    "count": "20",
+                    "sum": 3.141592653589793
+                  }
+                ],
+                "aggregationTemporality": 1
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/otlp/metrics/testdata/otlpdata/histogram/empty-delta-with-min-max.json
+++ b/pkg/otlp/metrics/testdata/otlpdata/histogram/empty-delta-with-min-max.json
@@ -1,0 +1,46 @@
+{
+  "resourceMetrics": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "host.name",
+            "value": {
+              "stringValue": "hostname"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "scope": {},
+          "metrics": [
+            {
+              "name": "doubleHist.empty.minmax.test",
+              "histogram": {
+                "dataPoints": [
+                  {
+                    "attributes": [
+                      {
+                        "key": "attribute_tag",
+                        "value": {
+                          "stringValue": "attribute_value"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "1667560641226420924",
+                    "count": "20",
+                    "sum": 3.141592653589793,
+                    "min": 100,
+                    "max": 101
+                  }
+                ],
+                "aggregationTemporality": 1
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/otlp/metrics/testdata/otlpdata/histogram/single-bucket-delta-no-min-max.json
+++ b/pkg/otlp/metrics/testdata/otlpdata/histogram/single-bucket-delta-no-min-max.json
@@ -1,0 +1,47 @@
+{
+  "resourceMetrics": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "host.name",
+            "value": {
+              "stringValue": "hostname"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "scope": {},
+          "metrics": [
+            {
+              "name": "doubleHist.singlebucket.test",
+              "histogram": {
+                "dataPoints": [
+                  {
+                    "attributes": [
+                      {
+                        "key": "attribute_tag",
+                        "value": {
+                          "stringValue": "attribute_value"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "1667560641226420924",
+                    "count": "20",
+                    "sum": 3.141592653589793,
+                    "bucketCounts": [
+                      "20"
+                    ]
+                  }
+                ],
+                "aggregationTemporality": 1
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/otlp/metrics/testdata/otlpdata/histogram/single-bucket-delta-with-min-max.json
+++ b/pkg/otlp/metrics/testdata/otlpdata/histogram/single-bucket-delta-with-min-max.json
@@ -1,0 +1,49 @@
+{
+  "resourceMetrics": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "host.name",
+            "value": {
+              "stringValue": "hostname"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "scope": {},
+          "metrics": [
+            {
+              "name": "doubleHist.singlebucket.minmax.test",
+              "histogram": {
+                "dataPoints": [
+                  {
+                    "attributes": [
+                      {
+                        "key": "attribute_tag",
+                        "value": {
+                          "stringValue": "attribute_value"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "1667560641226420924",
+                    "count": "20",
+                    "sum": 3.141592653589793,
+                    "min": 100,
+                    "max": 101,
+                    "bucketCounts": [
+                      "20"
+                    ]
+                  }
+                ],
+                "aggregationTemporality": 1
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

- [pkg/otlp/metrics] Refactor histogram loop to use slice
- [pkg/otlp/metrics] Add a single bucket for empty histograms

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

Fixes #252 by adding buckets representing the information conveyed by min, max, and count in the case a histogram is empty.
