### PR TITLE
Add stable Java runtime metric mappings

### DIFF
--- a/.chloggen/stanley.liu_add-stable-java-runtime-metrics.yaml
+++ b/.chloggen/stanley.liu_add-stable-java-runtime-metrics.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component (e.g. pkg/quantile)
+component: pkg/otlp/metrics
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Adds support for stable JVM metrics introduced in opentelemetry-java-instrumentation v2.0.0.
+
+# The PR related to this change
+issues: [265]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/pkg/otlp/metrics/runtime_metric_mappings.go
+++ b/pkg/otlp/metrics/runtime_metric_mappings.go
@@ -5,6 +5,7 @@ var runtimeMetricPrefixLanguageMap = map[string]string{
 	"process.runtime.go":     "go",
 	"process.runtime.dotnet": "dotnet",
 	"process.runtime.jvm":    "jvm",
+	"jvm":                    "jvm",
 }
 
 // runtimeMetricMapping defines the fields needed to map OTel runtime metrics to their equivalent
@@ -85,6 +86,140 @@ var dotnetRuntimeMetricsMappings = runtimeMetricMappingList{
 		attributes: []runtimeMetricAttribute{{
 			key:    "generation",
 			values: []string{"gen2"},
+		}},
+	}},
+}
+
+var stableJavaRuntimeMetricsMappings = runtimeMetricMappingList{
+	"jvm.thread.count":           {{mappedName: "jvm.thread_count"}},
+	"jvm.class.count":            {{mappedName: "jvm.loaded_classes"}},
+	"jvm.system.cpu.utilization": {{mappedName: "jvm.cpu_load.system"}},
+	"jvm.cpu.recent_utilization": {{mappedName: "jvm.cpu_load.process"}},
+	"jvm.memory.used": {{
+		mappedName: "jvm.heap_memory",
+		attributes: []runtimeMetricAttribute{{
+			key:    "jvm.memory.type",
+			values: []string{"heap"},
+		}},
+	}, {
+		mappedName: "jvm.non_heap_memory",
+		attributes: []runtimeMetricAttribute{{
+			key:    "jvm.memory.type",
+			values: []string{"non_heap"},
+		}},
+	}, {
+		mappedName: "jvm.gc.old_gen_size",
+		attributes: []runtimeMetricAttribute{{
+			key:    "jvm.memory.pool.name",
+			values: []string{"G1 Old Gen", "Tenured Gen", "PS Old Gen"},
+		}, {
+			key:    "jvm.memory.type",
+			values: []string{"heap"},
+		}},
+	}, {
+		mappedName: "jvm.gc.eden_size",
+		attributes: []runtimeMetricAttribute{{
+			key:    "jvm.memory.pool.name",
+			values: []string{"G1 Eden Space", "Eden Space", "Par Eden Space", "PS Eden Space"},
+		}, {
+			key:    "jvm.memory.type",
+			values: []string{"heap"},
+		}},
+	}, {
+		mappedName: "jvm.gc.survivor_size",
+		attributes: []runtimeMetricAttribute{{
+			key:    "jvm.memory.pool.name",
+			values: []string{"G1 Survivor Space", "Survivor Space", "Par Survivor Space", "PS Survivor Space"},
+		}, {
+			key:    "jvm.memory.type",
+			values: []string{"heap"},
+		}},
+	}, {
+		mappedName: "jvm.gc.metaspace_size",
+		attributes: []runtimeMetricAttribute{{
+			key:    "jvm.memory.pool.name",
+			values: []string{"Metaspace"},
+		}, {
+			key:    "jvm.memory.type",
+			values: []string{"non_heap"},
+		}},
+	}},
+	"jvm.memory.committed": {{
+		mappedName: "jvm.heap_memory_committed",
+		attributes: []runtimeMetricAttribute{{
+			key:    "jvm.memory.type",
+			values: []string{"heap"},
+		}},
+	}, {
+		mappedName: "jvm.non_heap_memory_committed",
+		attributes: []runtimeMetricAttribute{{
+			key:    "jvm.memory.type",
+			values: []string{"non_heap"},
+		}},
+	}},
+	"jvm.memory.init": {{
+		mappedName: "jvm.heap_memory_init",
+		attributes: []runtimeMetricAttribute{{
+			key:    "jvm.memory.type",
+			values: []string{"heap"},
+		}},
+	}, {
+		mappedName: "jvm.non_heap_memory_init",
+		attributes: []runtimeMetricAttribute{{
+			key:    "jvm.memory.type",
+			values: []string{"non_heap"},
+		}},
+	}},
+	"jvm.memory.limit": {{
+		mappedName: "jvm.heap_memory_max",
+		attributes: []runtimeMetricAttribute{{
+			key:    "jvm.memory.type",
+			values: []string{"heap"},
+		}},
+	}, {
+		mappedName: "jvm.non_heap_memory_max",
+		attributes: []runtimeMetricAttribute{{
+			key:    "jvm.memory.type",
+			values: []string{"non_heap"},
+		}},
+	}},
+	"jvm.buffer.memory.usage": {{
+		mappedName: "jvm.buffer_pool.direct.used",
+		attributes: []runtimeMetricAttribute{{
+			key:    "jvm.buffer.pool.name",
+			values: []string{"direct"},
+		}},
+	}, {
+		mappedName: "jvm.buffer_pool.mapped.used",
+		attributes: []runtimeMetricAttribute{{
+			key:    "jvm.buffer.pool.name",
+			values: []string{"mapped"},
+		}},
+	}},
+	"jvm.buffer.count": {{
+		mappedName: "jvm.buffer_pool.direct.count",
+		attributes: []runtimeMetricAttribute{{
+			key:    "jvm.buffer.pool.name",
+			values: []string{"direct"},
+		}},
+	}, {
+		mappedName: "jvm.buffer_pool.mapped.count",
+		attributes: []runtimeMetricAttribute{{
+			key:    "jvm.buffer.pool.name",
+			values: []string{"mapped"},
+		}},
+	}},
+	"jvm.buffer.memory.limit": {{
+		mappedName: "jvm.buffer_pool.direct.limit",
+		attributes: []runtimeMetricAttribute{{
+			key:    "jvm.buffer.pool.name",
+			values: []string{"direct"},
+		}},
+	}, {
+		mappedName: "jvm.buffer_pool.mapped.limit",
+		attributes: []runtimeMetricAttribute{{
+			key:    "jvm.buffer.pool.name",
+			values: []string{"mapped"},
 		}},
 	}},
 }
@@ -232,6 +367,9 @@ func getRuntimeMetricsMappings() runtimeMetricMappingList {
 		res[k] = v
 	}
 	for k, v := range javaRuntimeMetricsMappings {
+		res[k] = v
+	}
+	for k, v := range stableJavaRuntimeMetricsMappings {
 		res[k] = v
 	}
 	return res


### PR DESCRIPTION
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Adds runtime metric mappings for new stable JVM metrics added in [opentelemetry-java-instrumentation v2.0.0](https://github.com/open-telemetry/opentelemetry-java-instrumentation/releases/tag/v2.0.0).

Docs for new runtime metrics: https://opentelemetry.io/docs/specs/semconv/runtime/jvm-metrics/

Tested locally with OTel Java app instrumented with v2.0.0 and verified that metrics are mapping as intended.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

