### PR TITLE
[pkg/inframetadata] Add cloud conventions as host tags to host metadata

### DIFF
--- a/.chloggen/mx-psi_availability-zone.yaml
+++ b/.chloggen/mx-psi_availability-zone.yaml
@@ -1,0 +1,17 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component (e.g. pkg/quantile)
+component: inframetadata
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Automatically map `cloud.region`, `cloud.availability_zone` and `cloud.provider` to the `region`, `zone` and `cloud_provider` host tags.
+
+# The PR related to this change
+issues: [276]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: | 
+  - This will only happen if you have opted-in to mapping resource attributes to host metadata.

--- a/pkg/inframetadata/internal/hostmap/hostmap_test.go
+++ b/pkg/inframetadata/internal/hostmap/hostmap_test.go
@@ -264,7 +264,7 @@ func TestUpdate(t *testing.T) {
 			EC2Hostname: "host-1-hostname",
 			Hostname:    "host-1-hostid",
 		})
-		assert.ElementsMatch(t, md.Tags.OTel, []string{"foo:baz", "env:prod"})
+		assert.ElementsMatch(t, md.Tags.OTel, []string{"cloud_provider:aws", "foo:baz", "env:prod"})
 		assert.Equal(t, md.Payload.Gohai.Gohai.Platform, map[string]string{
 			"hostname":                    "host-1-hostid",
 			fieldPlatformOS:               "Fedora Linux",
@@ -303,7 +303,7 @@ func TestUpdate(t *testing.T) {
 		assert.Equal(t, md.Meta, &payload.Meta{
 			Hostname: "host-2-hostid",
 		})
-		assert.Equal(t, md.Tags, &payload.HostTags{})
+		assert.ElementsMatch(t, md.Tags.OTel, []string{"cloud_provider:azure"})
 		assert.Equal(t, md.Platform(), map[string]string{
 			"hostname":                    "host-2-hostid",
 			fieldPlatformProcessor:        "arm64",

--- a/pkg/inframetadata/internal/hostmap/tags.go
+++ b/pkg/inframetadata/internal/hostmap/tags.go
@@ -20,6 +20,9 @@ const hostTagPrefix = "datadog.host.tag."
 var hostTagMapping = map[string]string{
 	conventions.AttributeDeploymentEnvironment: "env",
 	conventions.AttributeK8SClusterName:        "cluster_name",
+	conventions.AttributeCloudProvider:         "cloud_provider",
+	conventions.AttributeCloudRegion:           "region",
+	conventions.AttributeCloudAvailabilityZone: "zone",
 }
 
 // assertStringValue returns the string value of the given value, or an error if the value is not a string.


### PR DESCRIPTION
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Adds `cloud.region`, `cloud.availability_zone` and `cloud.provider` as host tags
