### PR TITLE
[pkg/inframetadata] Improve warning when host-identifying attributes are missing

### DIFF
--- a/.chloggen/mx-psi_improve-warning.yaml
+++ b/.chloggen/mx-psi_improve-warning.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component (e.g. pkg/quantile)
+component: pkg/inframetadata
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fixes warning log where resource attributes were not correctly logged
+
+# The PR related to this change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/mx-psi_improve-warning.yaml
+++ b/.chloggen/mx-psi_improve-warning.yaml
@@ -8,7 +8,7 @@ component: pkg/inframetadata
 note: Fixes warning log where resource attributes were not correctly logged
 
 # The PR related to this change
-issues: []
+issues: [314]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/pkg/inframetadata/reporter.go
+++ b/pkg/inframetadata/reporter.go
@@ -109,7 +109,10 @@ func (r *Reporter) pushAndLog(ctx context.Context, hm payload.HostMetadata) {
 func (r *Reporter) hostname(res pcommon.Resource) (string, bool) {
 	src, ok := attributes.SourceFromAttrs(res.Attributes())
 	if !ok {
-		r.logger.Warn("resource does not have host-identifying attributes", zap.Any("attributes", res.Attributes()))
+		r.logger.Warn("resource does not have host-identifying attributes",
+			zap.Any("attributes", res.Attributes().AsRaw()),
+			zap.String("further info", "https://docs.datadoghq.com/opentelemetry/schema_semantics/hostname/?tab=datadogexporter"),
+		)
 		return "", false
 	}
 	if src.Kind != source.HostnameKind {


### PR DESCRIPTION
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Uses `AsRaw` for printing resource attributes and links reference page on mapping OTLP resource attributes to hostnames.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

`pcommon.Map` doesn't have a very sensible formatting. With the following sample program:

```go
package main

import (
	"go.opentelemetry.io/collector/pdata/pcommon"
	"go.uber.org/zap"
)

func main() {
	logger := zap.NewExample() // or NewProduction, or NewDevelopment
	defer logger.Sync()

	m := pcommon.NewMap()
	if err := m.FromRaw(map[string]any{"key": "value"}); err != nil {
		panic(err)
	}

	logger.Info("Testing logging of pcommon.Map", zap.Any("map", m), zap.Any("raw map", m.AsRaw()))
}
```

We can see the following output:

```
❯ go run main.go
{"level":"info","msg":"Testing logging of pcommon.Map","map":{},"raw map":{"key":"value"}}
```

Where `map` is shown as empty, when it isn't. Casting to a map with `AsRaw` fixes the issue