### PR TITLE
[pkg/otlp/metrics] Add tests for empty histograms

### DIFF
--- a/pkg/otlp/metrics/histograms_test.go
+++ b/pkg/otlp/metrics/histograms_test.go
@@ -51,6 +51,15 @@ func TestDeltaHistogramTranslatorOptions(t *testing.T) {
 			},
 		},
 		{
+			name:     "zero-count-histogram",
+			otlpfile: "testdata/otlpdata/histogram/zero-delta.json",
+			ddogfile: "testdata/datadogdata/histogram/zero-delta_dist-cs.json",
+			options: []TranslatorOption{
+				WithHistogramMode(HistogramModeDistributions),
+				WithHistogramAggregations(),
+			},
+		},
+		{
 			name:     "buckets",
 			otlpfile: "testdata/otlpdata/histogram/simple-delta.json",
 			ddogfile: "testdata/datadogdata/histogram/simple-delta_counters-nocs.json",
@@ -150,6 +159,15 @@ func TestCumulativeHistogramTranslatorOptions(t *testing.T) {
 			ddogfile: "testdata/datadogdata/histogram/simple-cumulative_dist-nocs.json",
 			options: []TranslatorOption{
 				WithHistogramMode(HistogramModeDistributions),
+			},
+		},
+		{
+			name:     "distributions",
+			otlpfile: "testdata/otlpdata/histogram/static-cumulative.json",
+			ddogfile: "testdata/datadogdata/histogram/static-cumulative_dist-cs.json",
+			options: []TranslatorOption{
+				WithHistogramMode(HistogramModeDistributions),
+				WithHistogramAggregations(),
 			},
 		},
 		{

--- a/pkg/otlp/metrics/testdata/datadogdata/histogram/static-cumulative_dist-cs.json
+++ b/pkg/otlp/metrics/testdata/datadogdata/histogram/static-cumulative_dist-cs.json
@@ -1,0 +1,29 @@
+{
+  "Sketches": null,
+  "TimeSeries": [
+    {
+      "Name": "doubleHist.test.count",
+      "Tags": [],
+      "Host": "hostname",
+      "OriginID": "",
+      "OriginProduct": 10,
+      "OriginCategory": 17,
+      "OriginService": 0,
+      "Type": "count",
+      "Timestamp": 1667560641226420925,
+      "Value": 0
+    },
+    {
+      "Name": "doubleHist.test.sum",
+      "Tags": [],
+      "Host": "hostname",
+      "OriginID": "",
+      "OriginProduct": 10,
+      "OriginCategory": 17,
+      "OriginService": 0,
+      "Type": "count",
+      "Timestamp": 1667560641226420925,
+      "Value": 0
+    }
+  ]
+}

--- a/pkg/otlp/metrics/testdata/datadogdata/histogram/zero-delta_dist-cs.json
+++ b/pkg/otlp/metrics/testdata/datadogdata/histogram/zero-delta_dist-cs.json
@@ -1,0 +1,61 @@
+{
+  "Sketches": null,
+  "TimeSeries": [
+    {
+      "Name": "doubleHist.test.count",
+      "Tags": [
+        "attribute_tag:attribute_value"
+      ],
+      "Host": "hostname",
+      "OriginID": "",
+      "OriginProduct": 10,
+      "OriginCategory": 17,
+      "OriginService": 0,
+      "Type": "count",
+      "Timestamp": 1667560641226420924,
+      "Value": 0
+    },
+    {
+      "Name": "doubleHist.test.sum",
+      "Tags": [
+        "attribute_tag:attribute_value"
+      ],
+      "Host": "hostname",
+      "OriginID": "",
+      "OriginProduct": 10,
+      "OriginCategory": 17,
+      "OriginService": 0,
+      "Type": "count",
+      "Timestamp": 1667560641226420924,
+      "Value": 0
+    },
+    {
+      "Name": "doubleHist.test.min",
+      "Tags": [
+        "attribute_tag:attribute_value"
+      ],
+      "Host": "hostname",
+      "OriginID": "",
+      "OriginProduct": 10,
+      "OriginCategory": 17,
+      "OriginService": 0,
+      "Type": "gauge",
+      "Timestamp": 1667560641226420924,
+      "Value": 0
+    },
+    {
+      "Name": "doubleHist.test.max",
+      "Tags": [
+        "attribute_tag:attribute_value"
+      ],
+      "Host": "hostname",
+      "OriginID": "",
+      "OriginProduct": 10,
+      "OriginCategory": 17,
+      "OriginService": 0,
+      "Type": "gauge",
+      "Timestamp": 1667560641226420924,
+      "Value": 0
+    }
+  ]
+}

--- a/pkg/otlp/metrics/testdata/otlpdata/histogram/static-cumulative.json
+++ b/pkg/otlp/metrics/testdata/otlpdata/histogram/static-cumulative.json
@@ -1,0 +1,59 @@
+{
+  "resourceMetrics": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "host.name",
+            "value": {
+              "stringValue": "hostname"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "scope": {},
+          "metrics": [
+            {
+              "name": "doubleHist.test",
+              "histogram": {
+                "dataPoints": [
+                  {
+                    "timeUnixNano": "1667560641226420924",
+                    "count": "20",
+                    "sum": 3.141592653589793,
+                    "min": -10,
+                    "max": 10,
+                    "bucketCounts": [
+                      "2",
+                      "18"
+                    ],
+                    "explicitBounds": [
+                      0
+                    ]
+                  },
+                  {
+                    "timeUnixNano": "1667560641226420925",
+                    "count": "20",
+                    "sum": 3.141592653589793,
+                    "min": -10,
+                    "max": 10,
+                    "bucketCounts": [
+                      "2",
+                      "18"
+                    ],
+                    "explicitBounds": [
+                      0
+                    ]
+                  }
+                ],
+                "aggregationTemporality": 2
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/pkg/otlp/metrics/testdata/otlpdata/histogram/zero-delta.json
+++ b/pkg/otlp/metrics/testdata/otlpdata/histogram/zero-delta.json
@@ -1,0 +1,53 @@
+{
+  "resourceMetrics": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "host.name",
+            "value": {
+              "stringValue": "hostname"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "scope": {},
+          "metrics": [
+            {
+              "name": "doubleHist.test",
+              "histogram": {
+                "dataPoints": [
+                  {
+                    "attributes": [
+                      {
+                        "key": "attribute_tag",
+                        "value": {
+                          "stringValue": "attribute_value"
+                        }
+                      }
+                    ],
+                    "timeUnixNano": "1667560641226420924",
+                    "count": "0",
+                    "sum": 0,
+                    "bucketCounts": [
+                      "0",
+                      "0"
+                    ],
+                    "explicitBounds": [
+                      0
+                    ],
+                    "min": 0,
+                    "max": 0
+                  }
+                ],
+                "aggregationTemporality": 1
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Add tests for histograms that do not have any points in them

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

This is inconsistent with how we deal with e.g. counters, so we will likely want to change this, but for now this just adds some testing scaffolding

