### PR TITLE
Add remaining entities to OriginIDFromAttributes

### DIFF
--- a/pkg/otlp/attributes/attributes.go
+++ b/pkg/otlp/attributes/attributes.go
@@ -152,6 +152,7 @@ func TagsFromAttributes(attrs pcommon.Map) []string {
 func OriginIDFromAttributes(attrs pcommon.Map) (originID string) {
 	// originID is always empty. Container ID is preferred over Kubernetes pod UID.
 	// Prefixes come from pkg/util/kubernetes/kubelet and pkg/util/containers.
+	// See https://github.com/DataDog/datadog-agent/tree/2b4f456/comp/core/tagger#entity-ids
 	if containerID, ok := attrs.Get(conventions.AttributeContainerID); ok {
 		originID = "container_id://" + containerID.AsString()
 	} else if containerImageName, ok := attrs.Get(conventions.AttributeContainerImageName); ok {

--- a/pkg/otlp/attributes/attributes.go
+++ b/pkg/otlp/attributes/attributes.go
@@ -154,8 +154,22 @@ func OriginIDFromAttributes(attrs pcommon.Map) (originID string) {
 	// Prefixes come from pkg/util/kubernetes/kubelet and pkg/util/containers.
 	if containerID, ok := attrs.Get(conventions.AttributeContainerID); ok {
 		originID = "container_id://" + containerID.AsString()
+	} else if containerImageName, ok := attrs.Get(conventions.AttributeContainerImageName); ok {
+		originID = "container_image_metadata://" + containerImageName.AsString()
+	} else if ecsTaskArn, ok := attrs.Get(conventions.AttributeAWSECSTaskARN); ok {
+		originID = "ecs_task://" + ecsTaskArn.AsString()
+	} else if hostName, ok := attrs.Get(conventions.AttributeHostName); ok {
+		originID = hostName.AsString()
+	} else if deploymentName, ok := attrs.Get(conventions.AttributeK8SDeploymentName); ok {
+		originID = "deployment://" + deploymentName.AsString()
+	} else if namespace, ok := attrs.Get(conventions.AttributeK8SNamespaceName); ok {
+		originID = "namespace://" + namespace.AsString()
+	} else if nodeUid, ok := attrs.Get(conventions.AttributeK8SNodeUID); ok {
+		originID = "kubernetes_node_uid://" + nodeUid.AsString()
 	} else if podUID, ok := attrs.Get(conventions.AttributeK8SPodUID); ok {
 		originID = "kubernetes_pod_uid://" + podUID.AsString()
+	} else if processPid, ok := attrs.Get(conventions.AttributeProcessPID); ok {
+		originID = "process://" + processPid.AsString()
 	}
 	return
 }

--- a/pkg/otlp/attributes/attributes.go
+++ b/pkg/otlp/attributes/attributes.go
@@ -158,8 +158,6 @@ func OriginIDFromAttributes(attrs pcommon.Map) (originID string) {
 		originID = "container_image_metadata://" + containerImageName.AsString()
 	} else if ecsTaskArn, ok := attrs.Get(conventions.AttributeAWSECSTaskARN); ok {
 		originID = "ecs_task://" + ecsTaskArn.AsString()
-	} else if hostName, ok := attrs.Get(conventions.AttributeHostName); ok {
-		originID = "host://" + hostName.AsString()
 	} else if deploymentName, ok := attrs.Get(conventions.AttributeK8SDeploymentName); ok {
 		originID = "deployment://" + deploymentName.AsString()
 	} else if namespace, ok := attrs.Get(conventions.AttributeK8SNamespaceName); ok {

--- a/pkg/otlp/attributes/attributes.go
+++ b/pkg/otlp/attributes/attributes.go
@@ -159,7 +159,7 @@ func OriginIDFromAttributes(attrs pcommon.Map) (originID string) {
 	} else if ecsTaskArn, ok := attrs.Get(conventions.AttributeAWSECSTaskARN); ok {
 		originID = "ecs_task://" + ecsTaskArn.AsString()
 	} else if hostName, ok := attrs.Get(conventions.AttributeHostName); ok {
-		originID = hostName.AsString()
+		originID = "host://" + hostName.AsString()
 	} else if deploymentName, ok := attrs.Get(conventions.AttributeK8SDeploymentName); ok {
 		originID = "deployment://" + deploymentName.AsString()
 	} else if namespace, ok := attrs.Get(conventions.AttributeK8SNamespaceName); ok {

--- a/pkg/otlp/attributes/attributes_test.go
+++ b/pkg/otlp/attributes/attributes_test.go
@@ -214,6 +214,50 @@ func TestOriginIDFromAttributes(t *testing.T) {
 			originID: "kubernetes_pod_uid://k8s_pod_uid_goes_here",
 		},
 		{
+			name: "only deployment name",
+			attrs: func() pcommon.Map {
+				attributes := pcommon.NewMap()
+				attributes.FromRaw(map[string]interface{}{
+					conventions.AttributeK8SDeploymentName: "k8s_deployment_name_goes_here",
+				})
+				return attributes
+			}(),
+			originID: "deployment://k8s_deployment_name_goes_here",
+		},
+		{
+			name: "only namespace name",
+			attrs: func() pcommon.Map {
+				attributes := pcommon.NewMap()
+				attributes.FromRaw(map[string]interface{}{
+					conventions.AttributeK8SNamespaceName: "k8s_namespace_goes_here",
+				})
+				return attributes
+			}(),
+			originID: "namespace://k8s_namespace_goes_here",
+		},
+		{
+			name: "only node UID",
+			attrs: func() pcommon.Map {
+				attributes := pcommon.NewMap()
+				attributes.FromRaw(map[string]interface{}{
+					conventions.AttributeK8SNodeUID: "k8s_node_uid_goes_here",
+				})
+				return attributes
+			}(),
+			originID: "kubernetes_node_uid://k8s_node_uid_goes_here",
+		},
+		{
+			name: "only process pid",
+			attrs: func() pcommon.Map {
+				attributes := pcommon.NewMap()
+				attributes.FromRaw(map[string]interface{}{
+					conventions.AttributeProcessPID: "process_pid_goes_here",
+				})
+				return attributes
+			}(),
+			originID: "process://process_pid_goes_here",
+		},
+		{
 			name:  "none",
 			attrs: pcommon.NewMap(),
 		},


### PR DESCRIPTION
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Adds remaining entities from entity list: https://github.com/DataDog/datadog-agent/tree/main/comp/core/tagger#entity-ids.

I'm not sure if we have proper mappings for `container_image_metadata`, `ecs_task` and `host`.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

