### PR TITLE
[OTEL-2048] Add otelcol_ prefix to internal metrics from trace agent

### DIFF
--- a/.chloggen/agent-metrics-prefix.yaml
+++ b/.chloggen/agent-metrics-prefix.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component (e.g. pkg/quantile)
+component: pkg/otlp/metrics
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Add `otelcol_` prefix to internal metrics from trace agent"
+
+# The PR related to this change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/agent-metrics-prefix.yaml
+++ b/.chloggen/agent-metrics-prefix.yaml
@@ -8,7 +8,7 @@ component: pkg/otlp/metrics
 note: "Add `otelcol_` prefix to internal metrics from trace agent"
 
 # The PR related to this change
-issues: []
+issues: [387]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/pkg/otlp/metrics/metrics_remapping.go
+++ b/pkg/otlp/metrics/metrics_remapping.go
@@ -239,9 +239,9 @@ func renameHostMetrics(m pmetric.Metric) {
 	}
 }
 
-var agentHTTPMetrics = map[string]struct{} {
-	"http_server_duration": struct{}{},
-	"http_server_request_size": struct{}{},
+var agentHTTPMetrics = map[string]struct{}{
+	"http_server_duration":      struct{}{},
+	"http_server_request_size":  struct{}{},
 	"http_server_response_size": struct{}{},
 }
 

--- a/pkg/otlp/metrics/metrics_remapping.go
+++ b/pkg/otlp/metrics/metrics_remapping.go
@@ -240,9 +240,9 @@ func renameHostMetrics(m pmetric.Metric) {
 }
 
 var agentHTTPMetrics = map[string]struct{}{
-	"http_server_duration":      struct{}{},
-	"http_server_request_size":  struct{}{},
-	"http_server_response_size": struct{}{},
+	"http_server_duration":      {},
+	"http_server_request_size":  {},
+	"http_server_response_size": {},
 }
 
 // isAgentInternalOTelMetric determines whether a metric is a internal metric in Agent on OTLP


### PR DESCRIPTION
### What does this PR do?

Add otelcol_ prefix to internal metrics from trace agent

### Motivation

Mitigate a breaking change from upstream

