### PR TITLE
[OTEL-2071] Map deployment.environment.name to env

### DIFF
--- a/.chloggen/new-env-conv.yaml
+++ b/.chloggen/new-env-conv.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component (e.g. pkg/quantile)
+component: pkg/otlp/attributes
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Map the new OTel semantic convention `deployment.environment.name` to `env`"
+
+# The PR related to this change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: "Mapping of the old convention `deployment.environment` stays the same"

--- a/.chloggen/new-env-conv.yaml
+++ b/.chloggen/new-env-conv.yaml
@@ -8,7 +8,7 @@ component: pkg/otlp/attributes
 note: "Map the new OTel semantic convention `deployment.environment.name` to `env`"
 
 # The PR related to this change
-issues: []
+issues: [400]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/pkg/inframetadata/internal/hostmap/hostmap_test.go
+++ b/pkg/inframetadata/internal/hostmap/hostmap_test.go
@@ -238,6 +238,7 @@ func TestUpdate(t *testing.T) {
 				conventions.AttributeHostID:        "host-2-hostid",
 				conventions.AttributeHostName:      "host-2-hostname",
 				conventions.AttributeHostArch:      conventions.AttributeHostArchARM64,
+				"deployment.environment.name":      "staging",
 			},
 		},
 	}
@@ -311,7 +312,7 @@ func TestUpdate(t *testing.T) {
 		assert.Equal(t, md.Meta, &payload.Meta{
 			Hostname: "host-2-hostid",
 		})
-		assert.ElementsMatch(t, md.Tags.OTel, []string{"cloud_provider:azure"})
+		assert.ElementsMatch(t, md.Tags.OTel, []string{"cloud_provider:azure", "env:staging"})
 		assert.Equal(t, md.Platform(), map[string]string{
 			"hostname":                    "host-2-hostid",
 			fieldPlatformProcessor:        "arm64",

--- a/pkg/inframetadata/internal/hostmap/tags.go
+++ b/pkg/inframetadata/internal/hostmap/tags.go
@@ -23,6 +23,9 @@ var hostTagMapping = map[string]string{
 	conventions.AttributeCloudProvider:         "cloud_provider",
 	conventions.AttributeCloudRegion:           "region",
 	conventions.AttributeCloudAvailabilityZone: "zone",
+
+	// TODO(OTEL-1766): import of semconv 1.27.0 is blocked on Go1.22 support
+	"deployment.environment.name": "env",
 }
 
 // assertStringValue returns the string value of the given value, or an error if the value is not a string.

--- a/pkg/otlp/attributes/attributes.go
+++ b/pkg/otlp/attributes/attributes.go
@@ -34,6 +34,9 @@ var (
 		conventions.AttributeDeploymentEnvironment: "env",
 		conventions.AttributeServiceName:           "service",
 		conventions.AttributeServiceVersion:        "version",
+
+		// TODO(OTEL-1766): import of semconv 1.27.0 is blocked on Go1.22 support
+		"deployment.environment.name": "env",
 	}
 
 	// ContainerMappings defines the mapping between OpenTelemetry semantic conventions

--- a/pkg/otlp/attributes/attributes_test.go
+++ b/pkg/otlp/attributes/attributes_test.go
@@ -58,6 +58,13 @@ func TestTagsFromAttributes(t *testing.T) {
 	}, TagsFromAttributes(attrs))
 }
 
+func TestNewDeploymentEnvironmentNameConvention(t *testing.T) {
+	attrs := pcommon.NewMap()
+	attrs.PutStr("deployment.environment.name", "staging")
+
+	assert.Equal(t, []string{"env:staging"}, TagsFromAttributes(attrs))
+}
+
 func TestTagsFromAttributesEmpty(t *testing.T) {
 	attrs := pcommon.NewMap()
 


### PR DESCRIPTION
### What does this PR do?

Map the new OTel semantic convention `deployment.environment.name` to `env`

### Motivation

Support [semconv v1.27.0](https://pkg.go.dev/go.opentelemetry.io/collector/semconv@v0.108.1/v1.27.0)

