### PR TITLE
[OTEL-2182] Stop prefixing some HTTP metrics with otelcol

### DIFF
--- a/.chloggen/metrics-prefix.yaml
+++ b/.chloggen/metrics-prefix.yaml
@@ -8,7 +8,7 @@ component: pkg/otlp/metrics
 note: Stop prefixing `http_server_duration`, `http_server_request_size` and `http_server_response_size` with `otelcol_`
 
 # The PR related to this change
-issues: []
+issues: [406]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/metrics-prefix.yaml
+++ b/.chloggen/metrics-prefix.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component (e.g. pkg/quantile)
+component: pkg/otlp/metrics
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Stop prefixing `http_server_duration`, `http_server_request_size` and `http_server_response_size` with `otelcol_`
+
+# The PR related to this change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/pkg/otlp/metrics/metrics_remapping.go
+++ b/pkg/otlp/metrics/metrics_remapping.go
@@ -239,17 +239,8 @@ func renameHostMetrics(m pmetric.Metric) {
 	}
 }
 
-var agentHTTPMetrics = map[string]struct{}{
-	"http_server_duration":      {},
-	"http_server_request_size":  {},
-	"http_server_response_size": {},
-}
-
 // isAgentInternalOTelMetric determines whether a metric is a internal metric in Agent on OTLP
 func isAgentInternalOTelMetric(name string) bool {
-	if _, ok := agentHTTPMetrics[name]; ok {
-		return true
-	}
 	return strings.HasPrefix(name, "datadog_trace_agent") || strings.HasPrefix(name, "datadog_otlp")
 }
 

--- a/pkg/otlp/metrics/metrics_remapping_test.go
+++ b/pkg/otlp/metrics/metrics_remapping_test.go
@@ -818,15 +818,15 @@ func TestRenameAgentMetrics(t *testing.T) {
 		},
 		{
 			in:           testMetric("http_server_duration", testPoint{f: 1}),
-			expectedName: "otelcol_http_server_duration",
+			expectedName: "http_server_duration",
 		},
 		{
 			in:           testMetric("http_server_request_size", testPoint{f: 1}),
-			expectedName: "otelcol_http_server_request_size",
+			expectedName: "http_server_request_size",
 		},
 		{
 			in:           testMetric("http_server_response_size", testPoint{f: 1}),
-			expectedName: "otelcol_http_server_response_size",
+			expectedName: "http_server_response_size",
 		},
 		// Verify no duplicated prefix is added (for metrics <= 0.105.0)
 		{


### PR DESCRIPTION
### What does this PR do?

Stop prefixing `http_server_duration`, `http_server_request_size` and `http_server_response_size` with `otelcol_`

### Motivation

These metrics can be from SDKs rather than collector. Stop prefixing them to be consistent with https://opentelemetry.io/docs/collector/internal-telemetry/#lists-of-internal-metrics
