### PR TITLE
[pkg/otlp/logs] upgrade datadog-api-client-go version

### DIFF
--- a/pkg/otlp/logs/go.mod
+++ b/pkg/otlp/logs/go.mod
@@ -3,7 +3,7 @@ module github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/logs
 go 1.22
 
 require (
-	github.com/DataDog/datadog-api-client-go/v2 v2.13.0
+	github.com/DataDog/datadog-api-client-go/v2 v2.33.0
 	github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes v0.21.0
 	github.com/stretchr/testify v1.9.0
 	go.opentelemetry.io/collector/component v0.94.1
@@ -21,8 +21,10 @@ require (
 	github.com/go-logr/logr v1.4.1 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-viper/mapstructure/v2 v2.0.0-alpha.1 // indirect
+	github.com/goccy/go-json v0.10.2 // indirect
 	github.com/gogo/protobuf v1.3.2 // indirect
 	github.com/golang/protobuf v1.5.3 // indirect
+	github.com/google/uuid v1.5.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/knadh/koanf/maps v0.1.1 // indirect
 	github.com/knadh/koanf/providers/confmap v0.1.0 // indirect

--- a/pkg/otlp/logs/go.sum
+++ b/pkg/otlp/logs/go.sum
@@ -1,5 +1,5 @@
-github.com/DataDog/datadog-api-client-go/v2 v2.13.0 h1:2c1dXSyUfum2YIVoYlqnBhV5JOG1cLSW+4jB3RrKjLc=
-github.com/DataDog/datadog-api-client-go/v2 v2.13.0/go.mod h1:kntOqXEh1SmjwSDzW/eJkr9kS7EqttvEkelglWtJRbg=
+github.com/DataDog/datadog-api-client-go/v2 v2.33.0 h1:OI6kDnJeQmkjfGzxmP0XUQUxMD4tp6oAPXnnJ4VpgUM=
+github.com/DataDog/datadog-api-client-go/v2 v2.33.0/go.mod h1:d3tOEgUd2kfsr9uuHQdY+nXrWp4uikgTgVCPdKNK30U=
 github.com/DataDog/zstd v1.5.2 h1:vUG4lAyuPCXO0TLbXvPv7EB7cNK1QV/luu55UHLrrn8=
 github.com/DataDog/zstd v1.5.2/go.mod h1:g4AWEaM3yOg3HYfnJ3YIawPnVdXJh9QME85blwSAmyw=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
@@ -16,6 +16,8 @@ github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
 github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre4VKE=
 github.com/go-viper/mapstructure/v2 v2.0.0-alpha.1 h1:TQcrn6Wq+sKGkpyPvppOz99zsMBaUOKXq6HSv655U1c=
 github.com/go-viper/mapstructure/v2 v2.0.0-alpha.1/go.mod h1:oJDH3BJKyqBA2TXFhDsKDGDTlndYOZ6rGS0BRZIxGhM=
+github.com/goccy/go-json v0.10.2 h1:CrxCmQqYDkv1z7lO7Wbh2HN93uovUHgrECaO5ZrCXAU=
+github.com/goccy/go-json v0.10.2/go.mod h1:6MelG93GURQebXPDq3khkgXZkazVtN9CRI+MGFi0w8I=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
 github.com/golang/protobuf v1.5.0/go.mod h1:FsONVRAS9T7sI+LIUmWTfcYkHO4aIWwzhcaSAoJOfIk=
@@ -26,6 +28,8 @@ github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
+github.com/google/uuid v1.5.0 h1:1p67kYwdtXjb0gL0BPiP1Av9wiZPo5A8z2cWkTZ+eyU=
+github.com/google/uuid v1.5.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=

--- a/pkg/otlp/logs/transform.go
+++ b/pkg/otlp/logs/transform.go
@@ -70,7 +70,7 @@ func Transform(lr plog.LogRecord, res pcommon.Resource, logger *zap.Logger) data
 
 func transform(lr plog.LogRecord, host, service string, res pcommon.Resource, logger *zap.Logger) datadogV2.HTTPLogItem {
 	l := datadogV2.HTTPLogItem{
-		AdditionalProperties: make(map[string]string),
+		AdditionalProperties: make(map[string]interface{}),
 	}
 	if host != "" {
 		l.Hostname = datadog.PtrString(host)
@@ -97,7 +97,7 @@ func transform(lr plog.LogRecord, host, service string, res pcommon.Resource, lo
 					zap.Error(err))
 				break
 			}
-			if l.AdditionalProperties[ddTraceID] == "" {
+			if _, ok := l.AdditionalProperties[ddTraceID]; !ok {
 				l.AdditionalProperties[ddTraceID] = strconv.FormatUint(traceIDToUint64(traceID), 10)
 				l.AdditionalProperties[otelTraceID] = v.AsString()
 			}
@@ -109,7 +109,7 @@ func transform(lr plog.LogRecord, host, service string, res pcommon.Resource, lo
 					zap.Error(err))
 				break
 			}
-			if l.AdditionalProperties[ddSpanID] == "" {
+			if _, ok := l.AdditionalProperties[ddSpanID]; !ok {
 				l.AdditionalProperties[ddSpanID] = strconv.FormatUint(spanIDToUint64(spanID), 10)
 				l.AdditionalProperties[otelSpanID] = v.AsString()
 			}

--- a/pkg/otlp/logs/transform_test.go
+++ b/pkg/otlp/logs/transform_test.go
@@ -62,7 +62,7 @@ func TestTranslator(t *testing.T) {
 			want: datadogV2.HTTPLogItem{
 				Ddtags:  datadog.PtrString("otel_source:test"),
 				Message: *datadog.PtrString(""),
-				AdditionalProperties: map[string]string{
+				AdditionalProperties: map[string]interface{}{
 					"app":              "test",
 					"status":           "debug",
 					otelSeverityNumber: "5",
@@ -89,7 +89,7 @@ func TestTranslator(t *testing.T) {
 				Ddtags:  datadog.PtrString("service:otlp_col,otel_source:test"),
 				Message: *datadog.PtrString(""),
 				Service: datadog.PtrString("otlp_col"),
-				AdditionalProperties: map[string]string{
+				AdditionalProperties: map[string]interface{}{
 					"app":              "test",
 					"status":           "debug",
 					otelSeverityNumber: "5",
@@ -118,7 +118,7 @@ func TestTranslator(t *testing.T) {
 				Ddtags:  datadog.PtrString("service:otlp_col,foo:bar,otel_source:test"),
 				Message: *datadog.PtrString(""),
 				Service: datadog.PtrString("otlp_col"),
-				AdditionalProperties: map[string]string{
+				AdditionalProperties: map[string]interface{}{
 					"app":              "test",
 					"status":           "debug",
 					otelSeverityNumber: "5",
@@ -146,7 +146,7 @@ func TestTranslator(t *testing.T) {
 				Ddtags:  datadog.PtrString("otel_source:test"),
 				Message: *datadog.PtrString(""),
 				Service: datadog.PtrString("otlp_col"),
-				AdditionalProperties: map[string]string{
+				AdditionalProperties: map[string]interface{}{
 					"app":              "test",
 					"status":           "debug",
 					otelSeverityNumber: "5",
@@ -175,7 +175,7 @@ func TestTranslator(t *testing.T) {
 				Ddtags:  datadog.PtrString("otel_source:test"),
 				Message: *datadog.PtrString(""),
 				Service: datadog.PtrString("otlp_col"),
-				AdditionalProperties: map[string]string{
+				AdditionalProperties: map[string]interface{}{
 					"app":              "test",
 					"status":           "debug",
 					otelSeverityNumber: "5",
@@ -208,7 +208,7 @@ func TestTranslator(t *testing.T) {
 				Ddtags:  datadog.PtrString("otel_source:test"),
 				Message: *datadog.PtrString(""),
 				Service: datadog.PtrString("otlp_col"),
-				AdditionalProperties: map[string]string{
+				AdditionalProperties: map[string]interface{}{
 					"app":              "test",
 					"status":           "debug",
 					otelSeverityNumber: "5",
@@ -241,7 +241,7 @@ func TestTranslator(t *testing.T) {
 				Ddtags:  datadog.PtrString("otel_source:test"),
 				Message: *datadog.PtrString(""),
 				Service: datadog.PtrString("otlp_col"),
-				AdditionalProperties: map[string]string{
+				AdditionalProperties: map[string]interface{}{
 					"app":              "test",
 					"status":           "debug",
 					otelSeverityNumber: "5",
@@ -274,7 +274,7 @@ func TestTranslator(t *testing.T) {
 				Ddtags:  datadog.PtrString("otel_source:test"),
 				Message: *datadog.PtrString(""),
 				Service: datadog.PtrString("otlp_col"),
-				AdditionalProperties: map[string]string{
+				AdditionalProperties: map[string]interface{}{
 					"app":              "test",
 					"status":           "debug",
 					otelSeverityNumber: "5",
@@ -305,7 +305,7 @@ func TestTranslator(t *testing.T) {
 				Ddtags:  datadog.PtrString("otel_source:test"),
 				Message: *datadog.PtrString(""),
 				Service: datadog.PtrString("otlp_col"),
-				AdditionalProperties: map[string]string{
+				AdditionalProperties: map[string]interface{}{
 					"app":              "test",
 					"status":           "debug",
 					otelSeverityNumber: "5",
@@ -336,7 +336,7 @@ func TestTranslator(t *testing.T) {
 				Ddtags:  datadog.PtrString("otel_source:test"),
 				Message: *datadog.PtrString(""),
 				Service: datadog.PtrString("otlp_col"),
-				AdditionalProperties: map[string]string{
+				AdditionalProperties: map[string]interface{}{
 					"app":              "test",
 					"status":           "alert",
 					otelSeverityText:   "alert",
@@ -371,7 +371,7 @@ func TestTranslator(t *testing.T) {
 				Ddtags:  datadog.PtrString("otel_source:test"),
 				Message: *datadog.PtrString(""),
 				Service: datadog.PtrString("otlp_col"),
-				AdditionalProperties: map[string]string{
+				AdditionalProperties: map[string]interface{}{
 					"message":          "This is log",
 					"app":              "test",
 					"status":           "warn",
@@ -406,7 +406,7 @@ func TestTranslator(t *testing.T) {
 				Ddtags:  datadog.PtrString("otel_source:test"),
 				Message: *datadog.PtrString(""),
 				Service: datadog.PtrString("otlp_col"),
-				AdditionalProperties: map[string]string{
+				AdditionalProperties: map[string]interface{}{
 					"message":      "This is log",
 					"app":          "test",
 					"status":       "error",
@@ -438,7 +438,7 @@ func TestTranslator(t *testing.T) {
 				Ddtags:  datadog.PtrString("service:otlp_col,otel_source:test"),
 				Message: *datadog.PtrString(""),
 				Service: datadog.PtrString("otlp_col"),
-				AdditionalProperties: map[string]string{
+				AdditionalProperties: map[string]interface{}{
 					"app":              "test",
 					"status":           "debug",
 					otelSeverityNumber: "5",
@@ -466,7 +466,7 @@ func TestTranslator(t *testing.T) {
 			want: datadogV2.HTTPLogItem{
 				Ddtags:  datadog.PtrString("service:otlp_col,otel_source:test"),
 				Message: *datadog.PtrString(""),
-				AdditionalProperties: map[string]string{
+				AdditionalProperties: map[string]interface{}{
 					"app":              "test",
 					"status":           "debug",
 					otelSeverityNumber: "5",
@@ -505,7 +505,7 @@ func TestTranslator(t *testing.T) {
 			want: datadogV2.HTTPLogItem{
 				Ddtags:  datadog.PtrString("otel_source:test"),
 				Message: *datadog.PtrString(""),
-				AdditionalProperties: map[string]string{
+				AdditionalProperties: map[string]interface{}{
 					"root.nest1.nest2":         "val",
 					"root.nest12.nest22.nest3": "val2",
 					"root.nest13":              "val3",
@@ -529,7 +529,7 @@ func TestTranslator(t *testing.T) {
 			want: datadogV2.HTTPLogItem{
 				Ddtags:  datadog.PtrString("otel_source:test"),
 				Message: *datadog.PtrString(""),
-				AdditionalProperties: map[string]string{
+				AdditionalProperties: map[string]interface{}{
 					"status": "",
 				},
 			},
@@ -579,7 +579,7 @@ func TestTranslator(t *testing.T) {
 			want: datadogV2.HTTPLogItem{
 				Ddtags:  datadog.PtrString("otel_source:test"),
 				Message: *datadog.PtrString(""),
-				AdditionalProperties: map[string]string{
+				AdditionalProperties: map[string]interface{}{
 					"nest1.nest2.nest3.nest4.nest5.nest6.nest7.nest8.nest9.nest10": "{\"nest11\":{\"nest12\":\"ok\"}}",
 					"nest1.nest2.nest3.nest4.nest5.nest14.nest15":                  "ok2",
 					"status": "",
@@ -603,7 +603,7 @@ func TestTranslator(t *testing.T) {
 			want: datadogV2.HTTPLogItem{
 				Ddtags:  datadog.PtrString("otel_source:test"),
 				Message: *datadog.PtrString(""),
-				AdditionalProperties: map[string]string{
+				AdditionalProperties: map[string]interface{}{
 					"status":           "debug",
 					otelSeverityNumber: "5",
 					ddTimestamp:        "2023-11-20T16:55:03.397Z",


### PR DESCRIPTION
### What does this PR do?

upgrade datadog-api-client-go version and fix breaking changes

### Motivation

one more step to unblock deps upgrade in https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/36532

