### PR TITLE
[OTEL-2361] Fix metric origin mappings from OTel collector receiver instrumentation scope

### DIFF
--- a/.chloggen/fix-metric-origin.yaml
+++ b/.chloggen/fix-metric-origin.yaml
@@ -8,7 +8,7 @@ component: pkg/otlp/metrics
 note: "Fix metric origin mappings from OTel collector receiver instrumentation scope"
 
 # The PR related to this change
-issues: []
+issues: [466]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.chloggen/fix-metric-origin.yaml
+++ b/.chloggen/fix-metric-origin.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'bug_fix'
+
+# The name of the component (e.g. pkg/quantile)
+component: pkg/otlp/metrics
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Fix metric origin mappings from OTel collector receiver instrumentation scope"
+
+# The PR related to this change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/pkg/otlp/metrics/origin.go
+++ b/pkg/otlp/metrics/origin.go
@@ -110,14 +110,14 @@ const (
 )
 
 func originProductDetailFromScopeName(scopeName string) OriginProductDetail {
-	const collectorPrefix = "otelcol/"
+	const collectorPrefix = "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/"
 	if !strings.HasPrefix(scopeName, collectorPrefix) {
 		return OriginProductDetailUnknown
 	}
 
-	// otelcol/kubeletstatsreceiver -> kubeletstatsreceiver
-	// otelcol/hostmetricsreceiver/disk -> hostmetricsreceiver
-	receiverName := strings.Split(scopeName, "/")[1]
+	// github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver -> kubeletstatsreceiver
+	// github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/disk -> hostmetricsreceiver
+	receiverName := strings.Split(scopeName, "/")[4]
 
 	// otelcol
 	switch receiverName {

--- a/pkg/otlp/metrics/origin_test.go
+++ b/pkg/otlp/metrics/origin_test.go
@@ -26,15 +26,19 @@ func TestOriginProductDetailFromScopeName(t *testing.T) {
 		expected  OriginProductDetail
 	}{
 		{
-			scopeName: "otelcol/notsupportedreceiver",
+			scopeName: "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/notsupportedreceiver",
 			expected:  OriginProductDetailUnknown,
 		},
 		{
 			scopeName: "otelcol/kubeletstatsreceiver",
+			expected:  OriginProductDetailUnknown,
+		},
+		{
+			scopeName: "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/kubeletstatsreceiver",
 			expected:  OriginProductDetailKubeletStatsReceiver,
 		},
 		{
-			scopeName: "otelcol/hostmetricsreceiver/memory",
+			scopeName: "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/memory",
 			expected:  OriginProductDetailHostMetricsReceiver,
 		},
 		{

--- a/pkg/otlp/metrics/testdata/otlpdata/origin/origin.json
+++ b/pkg/otlp/metrics/testdata/otlpdata/origin/origin.json
@@ -14,7 +14,7 @@
         "scopeMetrics": [
           {
             "scope": {
-              "name": "otelcol/unknownreceiver",
+              "name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/unknownreceiver",
               "version": "0.91.0"
             },
             "metrics": [
@@ -34,7 +34,7 @@
           },
           {
             "scope": {
-              "name": "otelcol/hostmetricsreceiver/memory",
+              "name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/hostmetricsreceiver/memory",
               "version": "1.0.0"
             },
             "metrics": [
@@ -54,7 +54,7 @@
           },
           {
             "scope": {
-              "name": "otelcol/prometheusreceiver",
+              "name": "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/prometheusreceiver",
               "version": "0.91.0"
             },
             "metrics": [


### PR DESCRIPTION
### What does this PR do?

Fix metric origin mappings from OTel collector receiver instrumentation scope

### Motivation

https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/34586 changed instrumentation scope from `otelcol/abc` to `github.com/open-telemetry/opentelemetry-collector-contrib/receiver/abc`

