### PR TITLE
Add gateway usage

### DIFF
--- a/pkg/inframetadata/reporter.go
+++ b/pkg/inframetadata/reporter.go
@@ -107,7 +107,7 @@ func (r *Reporter) pushAndLog(ctx context.Context, hm payload.HostMetadata) {
 }
 
 func (r *Reporter) hostname(res pcommon.Resource) (string, bool) {
-	src, ok := attributes.SourceFromAttrs(res.Attributes())
+	src, ok := attributes.SourceFromAttrs(res.Attributes(), nil)
 	if !ok {
 		r.logger.Warn("resource does not have host-identifying attributes",
 			zap.Any("attributes", res.Attributes().AsRaw()),

--- a/pkg/otlp/attributes/gateway_usage.go
+++ b/pkg/otlp/attributes/gateway_usage.go
@@ -1,0 +1,57 @@
+// Copyright  OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package attributes
+
+import "sync"
+
+type GatewayUsage struct {
+	fistHostname string
+	gatewayUsage bool
+	m            sync.Mutex
+}
+
+var _ HostFromAttributesHandler = (*GatewayUsage)(nil)
+
+// NewGatewayUsage returns a new GatewayUsage.
+// If two attributes have different hostnames, then we consider the setup is a gateway.
+func NewGatewayUsage() *GatewayUsage {
+	return &GatewayUsage{}
+}
+
+// OnHost implements HostFromAttributesHandler.
+func (g *GatewayUsage) OnHost(host string) {
+	g.m.Lock()
+	defer g.m.Unlock()
+	if g.fistHostname == "" {
+		g.fistHostname = host
+	} else if g.fistHostname != host {
+		g.gatewayUsage = true
+	}
+}
+
+// GatewayUsage returns true if the GatewayUsage was detected.
+func (g *GatewayUsage) GatewayUsage() bool {
+	g.m.Lock()
+	defer g.m.Unlock()
+	return g.gatewayUsage
+}
+
+// Gauge returns 1 if the GatewayUsage was detected, 0 otherwise.
+func (g *GatewayUsage) Gauge() float64 {
+	if g.GatewayUsage() {
+		return 1
+	}
+	return 0
+}

--- a/pkg/otlp/attributes/source_test.go
+++ b/pkg/otlp/attributes/source_test.go
@@ -155,7 +155,7 @@ func TestSourceFromAttrs(t *testing.T) {
 
 	for _, testInstance := range tests {
 		t.Run(testInstance.name, func(t *testing.T) {
-			source, ok := SourceFromAttrs(testInstance.attrs)
+			source, ok := SourceFromAttrs(testInstance.attrs, nil)
 			assert.Equal(t, testInstance.ok, ok)
 			assert.Equal(t, testInstance.src, source)
 		})
@@ -166,7 +166,7 @@ func TestSourceFromAttrs(t *testing.T) {
 func TestLiteralHostNonString(t *testing.T) {
 	attrs := pcommon.NewMap()
 	attrs.PutInt(AttributeHost, 1000)
-	src, ok := SourceFromAttrs(attrs)
+	src, ok := SourceFromAttrs(attrs, nil)
 	assert.True(t, ok)
 	assert.Equal(t, source.Source{Kind: source.HostnameKind, Identifier: "1000"}, src)
 }

--- a/pkg/otlp/attributes/translator.go
+++ b/pkg/otlp/attributes/translator.go
@@ -51,8 +51,8 @@ func NewTranslator(set component.TelemetrySettings) (*Translator, error) {
 }
 
 // ResourceToSource gets a telemetry signal source from its resource attributes.
-func (p *Translator) ResourceToSource(ctx context.Context, res pcommon.Resource, set attribute.Set) (source.Source, bool) {
-	src, ok := SourceFromAttrs(res.Attributes())
+func (p *Translator) ResourceToSource(ctx context.Context, res pcommon.Resource, set attribute.Set, hostFromAttributesHandler HostFromAttributesHandler) (source.Source, bool) {
+	src, ok := SourceFromAttrs(res.Attributes(), hostFromAttributesHandler)
 	if !ok {
 		p.missingSources.Add(ctx, 1, metric.WithAttributeSet(set))
 	}
@@ -67,5 +67,5 @@ func (p *Translator) ResourceToSource(ctx context.Context, res pcommon.Resource,
 // because of a fallback logic that will be removed. The attributes detected are resource attributes,
 // not attributes from a telemetry signal.
 func (p *Translator) AttributesToSource(_ context.Context, attrs pcommon.Map) (source.Source, bool) {
-	return SourceFromAttrs(attrs)
+	return SourceFromAttrs(attrs, nil)
 }

--- a/pkg/otlp/attributes/translator_test.go
+++ b/pkg/otlp/attributes/translator_test.go
@@ -70,9 +70,9 @@ func TestInternalTelemetryMetrics(t *testing.T) {
 
 	attributeSet := attribute.NewSet(attribute.String("signal", "test"))
 
-	_, _ = translator.ResourceToSource(context.Background(), resWithHostname, attributeSet)
-	_, _ = translator.ResourceToSource(context.Background(), resWithoutHostname, attributeSet)
-	_, _ = translator.ResourceToSource(context.Background(), resWithoutHostname, attributeSet)
+	_, _ = translator.ResourceToSource(context.Background(), resWithHostname, attributeSet, nil)
+	_, _ = translator.ResourceToSource(context.Background(), resWithoutHostname, attributeSet, nil)
+	_, _ = translator.ResourceToSource(context.Background(), resWithoutHostname, attributeSet, nil)
 
 	rm := &metricdata.ResourceMetrics{}
 	assert.NoError(t, reader.Collect(context.Background(), rm))

--- a/pkg/otlp/logs/transform.go
+++ b/pkg/otlp/logs/transform.go
@@ -200,13 +200,13 @@ func flattenAttribute(key string, val pcommon.Value, depth int) map[string]strin
 }
 
 func extractHostNameAndServiceName(resourceAttrs pcommon.Map, logAttrs pcommon.Map) (host string, service string) {
-	if src, ok := attributes.SourceFromAttrs(resourceAttrs); ok && src.Kind == source.HostnameKind {
+	if src, ok := attributes.SourceFromAttrs(resourceAttrs, nil); ok && src.Kind == source.HostnameKind {
 		host = src.Identifier
 	}
 	// HACK: Check for host in log record attributes if not present in resource attributes.
 	// This is not aligned with the specification and will be removed in the future.
 	if host == "" {
-		if src, ok := attributes.SourceFromAttrs(logAttrs); ok && src.Kind == source.HostnameKind {
+		if src, ok := attributes.SourceFromAttrs(logAttrs, nil); ok && src.Kind == source.HostnameKind {
 			host = src.Identifier
 		}
 	}

--- a/pkg/otlp/logs/translator.go
+++ b/pkg/otlp/logs/translator.go
@@ -48,7 +48,7 @@ func NewTranslator(set component.TelemetrySettings, attributesTranslator *attrib
 }
 
 func (t *Translator) hostNameAndServiceNameFromResource(ctx context.Context, res pcommon.Resource) (host string, service string) {
-	if src, ok := t.attributesTranslator.ResourceToSource(ctx, res, signalTypeSet); ok && src.Kind == source.HostnameKind {
+	if src, ok := t.attributesTranslator.ResourceToSource(ctx, res, signalTypeSet, nil); ok && src.Kind == source.HostnameKind {
 		host = src.Identifier
 	}
 	if s, ok := res.Attributes().Get(conventions.AttributeServiceName); ok {

--- a/pkg/otlp/metrics/metrics_translator.go
+++ b/pkg/otlp/metrics/metrics_translator.go
@@ -612,8 +612,8 @@ func (t *Translator) mapSummaryMetrics(
 	}
 }
 
-func (t *Translator) source(ctx context.Context, res pcommon.Resource) (source.Source, error) {
-	src, hasSource := t.attributesTranslator.ResourceToSource(ctx, res, signalTypeSet)
+func (t *Translator) source(ctx context.Context, res pcommon.Resource, hostFromAttributesHandler attributes.HostFromAttributesHandler) (source.Source, error) {
+	src, hasSource := t.attributesTranslator.ResourceToSource(ctx, res, signalTypeSet, hostFromAttributesHandler)
 	if !hasSource {
 		var err error
 		src, err = t.cfg.fallbackSourceProvider.Source(ctx)
@@ -726,14 +726,14 @@ func mapHistogramRuntimeMetricWithAttributes(md pmetric.Metric, metricsArray pme
 }
 
 // MapMetrics maps OTLP metrics into the Datadog format
-func (t *Translator) MapMetrics(ctx context.Context, md pmetric.Metrics, consumer Consumer) (Metadata, error) {
+func (t *Translator) MapMetrics(ctx context.Context, md pmetric.Metrics, consumer Consumer, hostFromAttributesHandler attributes.HostFromAttributesHandler) (Metadata, error) {
 	metadata := Metadata{
 		Languages: []string{},
 	}
 	rms := md.ResourceMetrics()
 	for i := 0; i < rms.Len(); i++ {
 		rm := rms.At(i)
-		src, err := t.source(ctx, rm.Resource())
+		src, err := t.source(ctx, rm.Resource(), hostFromAttributesHandler)
 		if err != nil {
 			return metadata, err
 		}

--- a/pkg/otlp/metrics/metrics_translator_benchmark_test.go
+++ b/pkg/otlp/metrics/metrics_translator_benchmark_test.go
@@ -228,7 +228,7 @@ func benchmarkMapMetrics(metrics pmetric.Metrics, b *testing.B) {
 		// Make deep copy of metrics to avoid mutation affecting benchmark tests
 		metricsCopy := pmetric.NewMetrics()
 		metrics.CopyTo(metricsCopy)
-		_, err := tr.MapMetrics(ctx, metricsCopy, consumer)
+		_, err := tr.MapMetrics(ctx, metricsCopy, consumer, nil)
 		assert.NoError(b, err)
 	}
 }

--- a/pkg/otlp/metrics/metrics_translator_test.go
+++ b/pkg/otlp/metrics/metrics_translator_test.go
@@ -487,7 +487,7 @@ func TestMapIntMonotonicWithRebootBeginningOfSlice(t *testing.T) {
 		ctx := context.Background()
 		consumer := &mockFullConsumer{}
 
-		rmt, _ := tr.MapMetrics(ctx, md, consumer)
+		rmt, _ := tr.MapMetrics(ctx, md, consumer, nil)
 		assert.ElementsMatch(t,
 			consumer.metrics,
 			[]metric{
@@ -528,7 +528,7 @@ func TestMapIntMonotonicWithRebootBeginningOfSlice(t *testing.T) {
 		ctx := context.Background()
 		consumer := &mockFullConsumer{}
 
-		rmt, _ := tr.MapMetrics(ctx, md, consumer)
+		rmt, _ := tr.MapMetrics(ctx, md, consumer, nil)
 		assert.ElementsMatch(t,
 			consumer.metrics,
 			[]metric{
@@ -573,7 +573,7 @@ func TestMapIntMonotonicDropPointPointWithinSlice(t *testing.T) {
 		tr := newTranslator(t, zap.NewNop())
 		consumer := &mockFullConsumer{}
 
-		rmt, _ := tr.MapMetrics(ctx, md, consumer)
+		rmt, _ := tr.MapMetrics(ctx, md, consumer, nil)
 		assert.ElementsMatch(t,
 			consumer.metrics,
 			[]metric{
@@ -616,7 +616,7 @@ func TestMapIntMonotonicDropPointPointWithinSlice(t *testing.T) {
 		tr := newTranslator(t, zap.NewNop())
 		consumer := &mockFullConsumer{}
 
-		rmt, _ := tr.MapMetrics(ctx, md, consumer)
+		rmt, _ := tr.MapMetrics(ctx, md, consumer, nil)
 		assert.ElementsMatch(t,
 			consumer.metrics,
 			[]metric{
@@ -657,7 +657,7 @@ func TestMapIntMonotonicDropPointPointWithinSlice(t *testing.T) {
 		tr := newTranslator(t, zap.NewNop())
 		consumer := &mockFullConsumer{}
 
-		rmt, _ := tr.MapMetrics(ctx, md, consumer)
+		rmt, _ := tr.MapMetrics(ctx, md, consumer, nil)
 		assert.ElementsMatch(t,
 			consumer.metrics,
 			[]metric{
@@ -700,7 +700,7 @@ func TestMapIntMonotonicDropPointPointWithinSlice(t *testing.T) {
 		tr := newTranslator(t, zap.NewNop())
 		consumer := &mockFullConsumer{}
 
-		rmt, _ := tr.MapMetrics(ctx, md, consumer)
+		rmt, _ := tr.MapMetrics(ctx, md, consumer, nil)
 		assert.ElementsMatch(t,
 			consumer.metrics,
 			[]metric{
@@ -744,7 +744,7 @@ func TestMapIntMonotonicDropPointPointBeginningOfSlice(t *testing.T) {
 		ctx := context.Background()
 		consumer := &mockFullConsumer{}
 
-		rmt, _ := tr.MapMetrics(ctx, md, consumer)
+		rmt, _ := tr.MapMetrics(ctx, md, consumer, nil)
 		assert.ElementsMatch(t,
 			consumer.metrics,
 			[]metric{
@@ -784,7 +784,7 @@ func TestMapIntMonotonicDropPointPointBeginningOfSlice(t *testing.T) {
 		ctx := context.Background()
 		consumer := &mockFullConsumer{}
 
-		rmt, _ := tr.MapMetrics(ctx, md, consumer)
+		rmt, _ := tr.MapMetrics(ctx, md, consumer, nil)
 		assert.ElementsMatch(t,
 			consumer.metrics,
 			[]metric{
@@ -824,7 +824,7 @@ func TestMapIntMonotonicDropPointPointBeginningOfSlice(t *testing.T) {
 		ctx := context.Background()
 		consumer := &mockFullConsumer{}
 
-		rmt, _ := tr.MapMetrics(ctx, md, consumer)
+		rmt, _ := tr.MapMetrics(ctx, md, consumer, nil)
 		assert.ElementsMatch(t,
 			consumer.metrics,
 			[]metric{
@@ -864,7 +864,7 @@ func TestMapIntMonotonicDropPointPointBeginningOfSlice(t *testing.T) {
 		ctx := context.Background()
 		consumer := &mockFullConsumer{}
 
-		rmt, _ := tr.MapMetrics(ctx, md, consumer)
+		rmt, _ := tr.MapMetrics(ctx, md, consumer, nil)
 		assert.ElementsMatch(t,
 			consumer.metrics,
 			[]metric{
@@ -880,7 +880,7 @@ func TestMapIntMonotonicReportFirstValue(t *testing.T) {
 	ctx := context.Background()
 	tr := newTranslator(t, zap.NewNop())
 	consumer := &mockFullConsumer{}
-	rmt, _ := tr.MapMetrics(ctx, createTestIntCumulativeMonotonicMetrics(false, exampleDims), consumer)
+	rmt, _ := tr.MapMetrics(ctx, createTestIntCumulativeMonotonicMetrics(false, exampleDims), consumer, nil)
 	startTs := int(getProcessStartTime()) + 1
 	assert.ElementsMatch(t,
 		consumer.metrics,
@@ -897,7 +897,7 @@ func TestMapIntMonotonicRateDontReportFirstValue(t *testing.T) {
 	ctx := context.Background()
 	tr := newTranslator(t, zap.NewNop())
 	consumer := &mockFullConsumer{}
-	rmt, _ := tr.MapMetrics(ctx, createTestIntCumulativeMonotonicMetrics(false, rateAsGaugeDims), consumer)
+	rmt, _ := tr.MapMetrics(ctx, createTestIntCumulativeMonotonicMetrics(false, rateAsGaugeDims), consumer, nil)
 	startTs := int(getProcessStartTime()) + 1
 	assert.ElementsMatch(t,
 		consumer.metrics,
@@ -913,7 +913,7 @@ func TestMapIntMonotonicNotReportFirstValueIfStartTSMatchTS(t *testing.T) {
 	ctx := context.Background()
 	tr := newTranslator(t, zap.NewNop())
 	consumer := &mockFullConsumer{}
-	rmt, _ := tr.MapMetrics(ctx, createTestIntCumulativeMonotonicMetrics(true, exampleDims), consumer)
+	rmt, _ := tr.MapMetrics(ctx, createTestIntCumulativeMonotonicMetrics(true, exampleDims), consumer, nil)
 	assert.Empty(t, consumer.metrics)
 	assert.Empty(t, rmt.Languages)
 }
@@ -922,7 +922,7 @@ func TestMapIntMonotonicRateNotReportFirstValueIfStartTSMatchTS(t *testing.T) {
 	ctx := context.Background()
 	tr := newTranslator(t, zap.NewNop())
 	consumer := &mockFullConsumer{}
-	rmt, _ := tr.MapMetrics(ctx, createTestIntCumulativeMonotonicMetrics(true, rateAsGaugeDims), consumer)
+	rmt, _ := tr.MapMetrics(ctx, createTestIntCumulativeMonotonicMetrics(true, rateAsGaugeDims), consumer, nil)
 	assert.Empty(t, consumer.metrics)
 	assert.Empty(t, rmt.Languages)
 }
@@ -935,7 +935,7 @@ func TestMapIntMonotonicReportDiffForFirstValue(t *testing.T) {
 	startTs := int(getProcessStartTime()) + 1
 	// Add an entry to the cache about the timeseries, in this case we send the diff (9) rather than the first value (10).
 	tr.prevPts.MonotonicDiff(dims, uint64(seconds(startTs)), uint64(seconds(startTs+1)), 1)
-	rmt, _ := tr.MapMetrics(ctx, createTestIntCumulativeMonotonicMetrics(false, exampleDims), consumer)
+	rmt, _ := tr.MapMetrics(ctx, createTestIntCumulativeMonotonicMetrics(false, exampleDims), consumer, nil)
 	assert.ElementsMatch(t,
 		consumer.metrics,
 		[]metric{
@@ -955,7 +955,7 @@ func TestMapIntMonotonicReportRateForFirstValue(t *testing.T) {
 	startTs := int(getProcessStartTime()) + 1
 	// Add an entry to the cache about the timeseries, in this case we send the rate (10-1)/(startTs+2-startTs+1) rather than the first value (10).
 	tr.prevPts.MonotonicDiff(dims, uint64(seconds(startTs)), uint64(seconds(startTs+1)), 1)
-	rmt, _ := tr.MapMetrics(ctx, createTestIntCumulativeMonotonicMetrics(false, rateAsGaugeDims), consumer)
+	rmt, _ := tr.MapMetrics(ctx, createTestIntCumulativeMonotonicMetrics(false, rateAsGaugeDims), consumer, nil)
 	assert.ElementsMatch(t,
 		consumer.metrics,
 		[]metric{
@@ -973,7 +973,7 @@ func TestMapRuntimeMetricsHasMapping(t *testing.T) {
 	consumer := &mockFullConsumer{}
 	exampleDims = newDims("process.runtime.go.goroutines")
 	mappedDims := newDims("runtime.go.num_goroutine")
-	rmt, err := tr.MapMetrics(ctx, createTestIntCumulativeMonotonicMetrics(false, exampleDims), consumer)
+	rmt, err := tr.MapMetrics(ctx, createTestIntCumulativeMonotonicMetrics(false, exampleDims), consumer, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -999,7 +999,7 @@ func TestMapRuntimeMetricsHasMappingCollector(t *testing.T) {
 	exampleDims = newDims("process.runtime.go.goroutines")
 	exampleOtelDims := newDims("otel.process.runtime.go.goroutines")
 	mappedDims := newDims("runtime.go.num_goroutine")
-	rmt, err := tr.MapMetrics(ctx, createTestIntCumulativeMonotonicMetrics(false, exampleDims), consumer)
+	rmt, err := tr.MapMetrics(ctx, createTestIntCumulativeMonotonicMetrics(false, exampleDims), consumer, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1027,7 +1027,7 @@ func TestMapSystemMetricsRenamedWithOTelPrefix(t *testing.T) {
 	processDims := newDims("process.runtime.go.goroutines")
 	jvmDims := newDims("jvm.memory.used")
 	for _, dims := range []*Dimensions{systemDims, processDims, jvmDims} {
-		_, err := tr.MapMetrics(ctx, createTestIntCumulativeMonotonicMetrics(false, dims), consumer)
+		_, err := tr.MapMetrics(ctx, createTestIntCumulativeMonotonicMetrics(false, dims), consumer, nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -1066,7 +1066,7 @@ func TestMapSumRuntimeMetricWithAttributesHasMapping(t *testing.T) {
 		key:    "generation",
 		values: []string{"gen0"},
 	}}
-	rmt, err := tr.MapMetrics(ctx, createTestMetricWithAttributes("process.runtime.dotnet.gc.collections.count", pmetric.MetricTypeSum, attributes, 1), consumer)
+	rmt, err := tr.MapMetrics(ctx, createTestMetricWithAttributes("process.runtime.dotnet.gc.collections.count", pmetric.MetricTypeSum, attributes, 1), consumer, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1089,7 +1089,7 @@ func TestMapSumRuntimeMetricWithAttributesHasMappingCollector(t *testing.T) {
 		key:    "generation",
 		values: []string{"gen0"},
 	}}
-	rmt, err := tr.MapMetrics(ctx, createTestMetricWithAttributes("process.runtime.dotnet.gc.collections.count", pmetric.MetricTypeSum, attributes, 1), consumer)
+	rmt, err := tr.MapMetrics(ctx, createTestMetricWithAttributes("process.runtime.dotnet.gc.collections.count", pmetric.MetricTypeSum, attributes, 1), consumer, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1112,7 +1112,7 @@ func TestMapGaugeRuntimeMetricWithAttributesHasMapping(t *testing.T) {
 		key:    "generation",
 		values: []string{"gen1"},
 	}}
-	rmt, err := tr.MapMetrics(ctx, createTestMetricWithAttributes("process.runtime.dotnet.gc.heap.size", pmetric.MetricTypeGauge, attributes, 1), consumer)
+	rmt, err := tr.MapMetrics(ctx, createTestMetricWithAttributes("process.runtime.dotnet.gc.heap.size", pmetric.MetricTypeGauge, attributes, 1), consumer, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1132,7 +1132,7 @@ func TestMapHistogramRuntimeMetricHasMapping(t *testing.T) {
 	tr := newTranslator(t, zap.NewNop())
 	consumer := &mockFullConsumer{}
 
-	rmt, err := tr.MapMetrics(ctx, createTestHistogramMetric("process.runtime.jvm.threads.count"), consumer)
+	rmt, err := tr.MapMetrics(ctx, createTestHistogramMetric("process.runtime.jvm.threads.count"), consumer, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1161,7 +1161,7 @@ func TestMapHistogramRuntimeMetricWithAttributesHasMapping(t *testing.T) {
 		key:    "generation",
 		values: []string{"gen1"},
 	}}
-	rmt, err := tr.MapMetrics(ctx, createTestMetricWithAttributes("process.runtime.dotnet.gc.heap.size", pmetric.MetricTypeHistogram, attributes, 1), consumer)
+	rmt, err := tr.MapMetrics(ctx, createTestMetricWithAttributes("process.runtime.dotnet.gc.heap.size", pmetric.MetricTypeHistogram, attributes, 1), consumer, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1193,7 +1193,7 @@ func TestMapRuntimeMetricWithTwoAttributesHasMapping(t *testing.T) {
 		key:    "type",
 		values: []string{"heap"},
 	}}
-	rmt, err := tr.MapMetrics(ctx, createTestMetricWithAttributes("process.runtime.jvm.memory.usage", pmetric.MetricTypeGauge, attributes, 1), consumer)
+	rmt, err := tr.MapMetrics(ctx, createTestMetricWithAttributes("process.runtime.jvm.memory.usage", pmetric.MetricTypeGauge, attributes, 1), consumer, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1220,7 +1220,7 @@ func TestMapRuntimeMetricWithTwoAttributesMultipleDataPointsHasMapping(t *testin
 		key:    "type",
 		values: []string{"heap", "heap", "heap"},
 	}}
-	rmt, err := tr.MapMetrics(ctx, createTestMetricWithAttributes("process.runtime.jvm.memory.usage", pmetric.MetricTypeGauge, attributes, 3), consumer)
+	rmt, err := tr.MapMetrics(ctx, createTestMetricWithAttributes("process.runtime.jvm.memory.usage", pmetric.MetricTypeGauge, attributes, 3), consumer, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1248,7 +1248,7 @@ func TestMapRuntimeMetricsMultipleLanguageTags(t *testing.T) {
 	consumer := &mockFullConsumer{}
 	exampleDims = newDims("process.runtime.go.goroutines")
 	md1 := createTestIntCumulativeMonotonicMetrics(false, exampleDims)
-	rmt, err := tr.MapMetrics(ctx, md1, consumer)
+	rmt, err := tr.MapMetrics(ctx, md1, consumer, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1257,7 +1257,7 @@ func TestMapRuntimeMetricsMultipleLanguageTags(t *testing.T) {
 	exampleDims = newDims("process.runtime.go.lookups")
 	md2 := createTestIntCumulativeMonotonicMetrics(false, exampleDims)
 	md1.ResourceMetrics().MoveAndAppendTo(md2.ResourceMetrics())
-	rmt, err = tr.MapMetrics(ctx, md2, consumer)
+	rmt, err = tr.MapMetrics(ctx, md2, consumer, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1266,7 +1266,7 @@ func TestMapRuntimeMetricsMultipleLanguageTags(t *testing.T) {
 	exampleDims = newDims("process.runtime.dotnet.exceptions.count")
 	md3 := createTestIntCumulativeMonotonicMetrics(false, exampleDims)
 	md2.ResourceMetrics().MoveAndAppendTo(md3.ResourceMetrics())
-	rmt, err = tr.MapMetrics(ctx, md3, consumer)
+	rmt, err = tr.MapMetrics(ctx, md3, consumer, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1275,7 +1275,7 @@ func TestMapRuntimeMetricsMultipleLanguageTags(t *testing.T) {
 	exampleDims = newDims("process.runtime.jvm.classes.current_loaded")
 	md4 := createTestIntCumulativeMonotonicMetrics(false, exampleDims)
 	md3.ResourceMetrics().MoveAndAppendTo(md4.ResourceMetrics())
-	rmt, err = tr.MapMetrics(ctx, md4, consumer)
+	rmt, err = tr.MapMetrics(ctx, md4, consumer, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1290,7 +1290,7 @@ func TestMapGaugeRuntimeMetricWithInvalidAttributes(t *testing.T) {
 		key:    "type",
 		values: []string{"heap2"},
 	}}
-	rmt, err := tr.MapMetrics(ctx, createTestMetricWithAttributes("process.runtime.jvm.memory.usage", pmetric.MetricTypeGauge, attributes, 1), consumer)
+	rmt, err := tr.MapMetrics(ctx, createTestMetricWithAttributes("process.runtime.jvm.memory.usage", pmetric.MetricTypeGauge, attributes, 1), consumer, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1309,7 +1309,7 @@ func TestMapRuntimeMetricsNoMapping(t *testing.T) {
 	tr := newTranslator(t, zap.NewNop())
 	consumer := &mockFullConsumer{}
 	exampleDims = newDims("runtime.go.mem.live_objects")
-	rmt, err := tr.MapMetrics(ctx, createTestIntCumulativeMonotonicMetrics(false, exampleDims), consumer)
+	rmt, err := tr.MapMetrics(ctx, createTestIntCumulativeMonotonicMetrics(false, exampleDims), consumer, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1329,7 +1329,7 @@ func TestMapSystemMetrics(t *testing.T) {
 	ctx := context.Background()
 	tr := NewTestTranslator(t, WithRemapping())
 	consumer := &mockFullConsumer{}
-	rmt, err := tr.MapMetrics(ctx, createTestMetricWithAttributes("system.filesystem.utilization", pmetric.MetricTypeGauge, nil, 1), consumer)
+	rmt, err := tr.MapMetrics(ctx, createTestMetricWithAttributes("system.filesystem.utilization", pmetric.MetricTypeGauge, nil, 1), consumer, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -1555,7 +1555,7 @@ func TestMapDoubleMonotonicWithRebootBeginningOfSlice(t *testing.T) {
 		ctx := context.Background()
 		consumer := &mockFullConsumer{}
 
-		rmt, _ := tr.MapMetrics(ctx, md, consumer)
+		rmt, _ := tr.MapMetrics(ctx, md, consumer, nil)
 		assert.ElementsMatch(t,
 			consumer.metrics,
 			[]metric{
@@ -1596,7 +1596,7 @@ func TestMapDoubleMonotonicWithRebootBeginningOfSlice(t *testing.T) {
 		ctx := context.Background()
 		consumer := &mockFullConsumer{}
 
-		rmt, _ := tr.MapMetrics(ctx, md, consumer)
+		rmt, _ := tr.MapMetrics(ctx, md, consumer, nil)
 		assert.ElementsMatch(t,
 			consumer.metrics,
 			[]metric{
@@ -1642,7 +1642,7 @@ func TestMapDoubleMonotonicDropPointPointWithinSlice(t *testing.T) {
 		tr := newTranslator(t, zap.NewNop())
 		consumer := &mockFullConsumer{}
 
-		rmt, _ := tr.MapMetrics(ctx, md, consumer)
+		rmt, _ := tr.MapMetrics(ctx, md, consumer, nil)
 		assert.ElementsMatch(t,
 			consumer.metrics,
 			[]metric{
@@ -1685,7 +1685,7 @@ func TestMapDoubleMonotonicDropPointPointWithinSlice(t *testing.T) {
 		tr := newTranslator(t, zap.NewNop())
 		consumer := &mockFullConsumer{}
 
-		rmt, _ := tr.MapMetrics(ctx, md, consumer)
+		rmt, _ := tr.MapMetrics(ctx, md, consumer, nil)
 		assert.ElementsMatch(t,
 			consumer.metrics,
 			[]metric{
@@ -1726,7 +1726,7 @@ func TestMapDoubleMonotonicDropPointPointWithinSlice(t *testing.T) {
 		tr := newTranslator(t, zap.NewNop())
 		consumer := &mockFullConsumer{}
 
-		rmt, _ := tr.MapMetrics(ctx, md, consumer)
+		rmt, _ := tr.MapMetrics(ctx, md, consumer, nil)
 		assert.ElementsMatch(t,
 			consumer.metrics,
 			[]metric{
@@ -1769,7 +1769,7 @@ func TestMapDoubleMonotonicDropPointPointWithinSlice(t *testing.T) {
 		tr := newTranslator(t, zap.NewNop())
 		consumer := &mockFullConsumer{}
 
-		rmt, _ := tr.MapMetrics(ctx, md, consumer)
+		rmt, _ := tr.MapMetrics(ctx, md, consumer, nil)
 		assert.ElementsMatch(t,
 			consumer.metrics,
 			[]metric{
@@ -1813,7 +1813,7 @@ func TestMapDoubleMonotonicDropPointPointBeginningOfSlice(t *testing.T) {
 		ctx := context.Background()
 		consumer := &mockFullConsumer{}
 
-		rmt, _ := tr.MapMetrics(ctx, md, consumer)
+		rmt, _ := tr.MapMetrics(ctx, md, consumer, nil)
 		assert.ElementsMatch(t,
 			consumer.metrics,
 			[]metric{
@@ -1853,7 +1853,7 @@ func TestMapDoubleMonotonicDropPointPointBeginningOfSlice(t *testing.T) {
 		ctx := context.Background()
 		consumer := &mockFullConsumer{}
 
-		rmt, _ := tr.MapMetrics(ctx, md, consumer)
+		rmt, _ := tr.MapMetrics(ctx, md, consumer, nil)
 		assert.ElementsMatch(t,
 			consumer.metrics,
 			[]metric{
@@ -1868,7 +1868,7 @@ func TestMapDoubleMonotonicReportFirstValue(t *testing.T) {
 	ctx := context.Background()
 	tr := newTranslator(t, zap.NewNop())
 	consumer := &mockFullConsumer{}
-	tr.MapMetrics(ctx, createTestDoubleCumulativeMonotonicMetrics(false, exampleDims), consumer)
+	tr.MapMetrics(ctx, createTestDoubleCumulativeMonotonicMetrics(false, exampleDims), consumer, nil)
 	startTs := int(getProcessStartTime()) + 1
 	assert.ElementsMatch(t,
 		consumer.metrics,
@@ -1884,7 +1884,7 @@ func TestMapDoubleMonotonicRateDontReportFirstValue(t *testing.T) {
 	ctx := context.Background()
 	tr := newTranslator(t, zap.NewNop())
 	consumer := &mockFullConsumer{}
-	rmt, _ := tr.MapMetrics(ctx, createTestDoubleCumulativeMonotonicMetrics(false, rateAsGaugeDims), consumer)
+	rmt, _ := tr.MapMetrics(ctx, createTestDoubleCumulativeMonotonicMetrics(false, rateAsGaugeDims), consumer, nil)
 	startTs := int(getProcessStartTime()) + 1
 	assert.ElementsMatch(t,
 		consumer.metrics,
@@ -1900,7 +1900,7 @@ func TestMapDoubleMonotonicNotReportFirstValueIfStartTSMatchTS(t *testing.T) {
 	ctx := context.Background()
 	tr := newTranslator(t, zap.NewNop())
 	consumer := &mockFullConsumer{}
-	tr.MapMetrics(ctx, createTestDoubleCumulativeMonotonicMetrics(true, exampleDims), consumer)
+	tr.MapMetrics(ctx, createTestDoubleCumulativeMonotonicMetrics(true, exampleDims), consumer, nil)
 	assert.Empty(t, consumer.metrics)
 }
 
@@ -1917,7 +1917,7 @@ func TestMapAPMStatsWithBytes(t *testing.T) {
 	assert.NoError(t, err)
 
 	ctx := context.Background()
-	tr.MapMetrics(ctx, md, consumer)
+	tr.MapMetrics(ctx, md, consumer, nil)
 	got := &pb.StatsPayload{}
 
 	payload := <-ch
@@ -1934,7 +1934,7 @@ func TestMapDoubleMonotonicReportDiffForFirstValue(t *testing.T) {
 	startTs := int(getProcessStartTime()) + 1
 	// Add an entry to the cache about the timeseries, in this case we send the diff (9) rather than the first value (10).
 	tr.prevPts.MonotonicDiff(dims, uint64(seconds(startTs)), uint64(seconds(startTs+1)), 1)
-	tr.MapMetrics(ctx, createTestDoubleCumulativeMonotonicMetrics(false, exampleDims), consumer)
+	tr.MapMetrics(ctx, createTestDoubleCumulativeMonotonicMetrics(false, exampleDims), consumer, nil)
 	assert.ElementsMatch(t,
 		consumer.metrics,
 		[]metric{
@@ -1953,7 +1953,7 @@ func TestMapDoubleMonotonicReportRateForFirstValue(t *testing.T) {
 	startTs := int(getProcessStartTime()) + 1
 	// Add an entry to the cache about the timeseries, in this case we send the rate (10-1)/(startTs+2-startTs+1) rather than the first value (10).
 	tr.prevPts.MonotonicDiff(dims, uint64(seconds(startTs)), uint64(seconds(startTs+1)), 1)
-	rmt, _ := tr.MapMetrics(ctx, createTestDoubleCumulativeMonotonicMetrics(false, rateAsGaugeDims), consumer)
+	rmt, _ := tr.MapMetrics(ctx, createTestDoubleCumulativeMonotonicMetrics(false, rateAsGaugeDims), consumer, nil)
 	assert.ElementsMatch(t,
 		consumer.metrics,
 		[]metric{

--- a/pkg/otlp/metrics/nan_metrics_test.go
+++ b/pkg/otlp/metrics/nan_metrics_test.go
@@ -156,7 +156,7 @@ func TestNaNMetrics(t *testing.T) {
 	ctx := context.Background()
 	tr := newTranslator(t, testLogger)
 	consumer := &mockFullConsumer{}
-	_, err := tr.MapMetrics(ctx, md, consumer)
+	_, err := tr.MapMetrics(ctx, md, consumer, nil)
 	require.NoError(t, err)
 
 	assert.ElementsMatch(t, consumer.metrics, []metric{

--- a/pkg/otlp/metrics/sketches_test.go
+++ b/pkg/otlp/metrics/sketches_test.go
@@ -143,7 +143,7 @@ func TestHistogramSketches(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			md := fromCDF(test.cdf)
 			consumer := &sketchConsumer{}
-			_, err := tr.MapMetrics(ctx, md, consumer)
+			_, err := tr.MapMetrics(ctx, md, consumer, nil)
 			assert.NoError(t, err)
 			sk := consumer.sk
 
@@ -340,7 +340,7 @@ func TestExactHistogramStats(t *testing.T) {
 		t.Run(testInstance.name, func(t *testing.T) {
 			md := testInstance.getHist()
 			consumer := &sketchConsumer{}
-			_, err := tr.MapMetrics(ctx, md, consumer)
+			_, err := tr.MapMetrics(ctx, md, consumer, nil)
 			assert.NoError(t, err)
 			sk := consumer.sk
 
@@ -424,7 +424,7 @@ func TestInfiniteBounds(t *testing.T) {
 		t.Run(testInstance.name, func(t *testing.T) {
 			md := testInstance.getHist()
 			consumer := &sketchConsumer{}
-			_, err := tr.MapMetrics(ctx, md, consumer)
+			_, err := tr.MapMetrics(ctx, md, consumer, nil)
 			assert.NoError(t, err)
 			sk := consumer.sk
 
@@ -566,7 +566,7 @@ func TestKnownDistributionsQuantile(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			md := fromQuantile(name, startTime, timeNow, tt.quantile, N, M)
 			consumer := &sketchConsumer{}
-			_, err := tr.MapMetrics(ctx, md, consumer)
+			_, err := tr.MapMetrics(ctx, md, consumer, nil)
 			require.NoError(t, err)
 			require.NotNil(t, consumer.sk)
 

--- a/pkg/otlp/metrics/testhelper_test.go
+++ b/pkg/otlp/metrics/testhelper_test.go
@@ -108,7 +108,7 @@ func AssertTranslatorMap(t TestingT, translator *Translator, otlpfilename string
 
 	// Map metrics using translator.
 	var consumer testConsumer
-	_, err = translator.MapMetrics(context.Background(), otlpdata, &consumer)
+	_, err = translator.MapMetrics(context.Background(), otlpdata, &consumer, nil)
 	require.NoError(t, err)
 
 	if !assert.Equal(t, expecteddata, consumer.testMetrics) {


### PR DESCRIPTION
### What does this PR do?

This PR adds a way to know if OTEL is used in a gateway setup.
In order to do so, it checks if `datadog.host.name` was sent with two different values.

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

