### PR TITLE
[OTAGENT-295] Bump required minimum Go version to 1.23

### DIFF
--- a/.chloggen/go-version.yaml
+++ b/.chloggen/go-version.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component (e.g. pkg/quantile)
+component: all
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Bump required minimum Go version to 1.23"
+
+# The PR related to this change
+issues: []
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/.chloggen/go-version.yaml
+++ b/.chloggen/go-version.yaml
@@ -8,7 +8,7 @@ component: all
 note: "Bump required minimum Go version to 1.23"
 
 # The PR related to this change
-issues: []
+issues: [517]
 
 # (Optional) One or more lines of additional information to render under the primary note.
 # These lines will be padded with 2 spaces and then inserted directly into the document.

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -37,7 +37,7 @@ jobs:
           fetch-depth: 0
       - uses: actions/setup-go@v5
         with:
-          go-version: "1.22.9"
+          go-version: "1.23.0"
           cache: false
       - name: Cache Go
         id: go-cache

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,7 +20,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.22.8"
+          go-version: "1.23.0"
       - name: Cache Go
         id: go-cache
         uses: actions/cache@v4
@@ -39,7 +39,7 @@ jobs:
   unittest:
     strategy:
       matrix:
-        go-version: ["1.23.0", "1.22.8"]
+        go-version: ["1.23.0", "1.24.0"]
     runs-on: ubuntu-latest
     needs: [setup-environment]
     steps:
@@ -72,7 +72,7 @@ jobs:
           files: testresults/
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@13ce06bfc6bbe3ecf90edbbf1bc32fe5978ca1d3 # 5.3.1
-        if: startsWith( matrix.go-version, '1.22' )
+        if: startsWith( matrix.go-version, '1.23' )
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
       - name: cleanup
@@ -88,7 +88,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.22.8"
+          go-version: "1.23.0"
       - name: Cache Go
         id: go-cache
         uses: actions/cache@v4
@@ -140,7 +140,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v5
         with:
-          go-version: "1.22.8"
+          go-version: "1.23.0"
 
       - name: Install tools
         run: |

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ for-all: $(GOMODULES)
 # Tidy go.mod/go.sum for all modules
 .PHONY: tidy
 tidy:
-	@$(MAKE) for-all CMD="go mod tidy -compat=1.22"
+	@$(MAKE) for-all CMD="go mod tidy -compat=1.23"
 
 # Format code for all modules
 .PHONY: fmt

--- a/internal/tools/go.mod
+++ b/internal/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/opentelemetry-mapping-go/internal/tools
 
-go 1.22.1
+go 1.23.0
 
 require (
 	github.com/frapposelli/wwhrd v0.4.0

--- a/pkg/inframetadata/go.mod
+++ b/pkg/inframetadata/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/opentelemetry-mapping-go/pkg/inframetadata
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes v0.25.0

--- a/pkg/inframetadata/gohai/internal/gohaitest/go.mod
+++ b/pkg/inframetadata/gohai/internal/gohaitest/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/opentelemetry-mapping-go/pkg/inframetadata/gohai/internal/gohaitest
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/DataDog/gohai v0.0.0-20230524154621-4316413895ee

--- a/pkg/internal/sketchtest/go.mod
+++ b/pkg/internal/sketchtest/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/opentelemetry-mapping-go/pkg/internal/sketchtest
 
-go 1.22
+go 1.23
 
 require github.com/stretchr/testify v1.10.0
 

--- a/pkg/otlp/attributes/go.mod
+++ b/pkg/otlp/attributes/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/attributes
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/stretchr/testify v1.10.0

--- a/pkg/otlp/logs/go.mod
+++ b/pkg/otlp/logs/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/logs
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/DataDog/datadog-api-client-go/v2 v2.35.0

--- a/pkg/otlp/metrics/go.mod
+++ b/pkg/otlp/metrics/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/opentelemetry-mapping-go/pkg/otlp/metrics
 
-go 1.22.0
+go 1.23.0
 
 require (
 	github.com/DataDog/datadog-agent/pkg/proto v0.64.0-devel

--- a/pkg/quantile/go.mod
+++ b/pkg/quantile/go.mod
@@ -1,6 +1,6 @@
 module github.com/DataDog/opentelemetry-mapping-go/pkg/quantile
 
-go 1.22
+go 1.23
 
 require (
 	github.com/DataDog/opentelemetry-mapping-go/pkg/internal/sketchtest v0.25.0


### PR DESCRIPTION
### What does this PR do?

Bump required minimum Go version to 1.23. Add testing for Go 1.24, drop testing for Go 1.22.

### Motivation

This is consistent with the versions supported in OTel collector upstream

