### PR TITLE
[OTEL-2506] Convert OTel instrumentation scope attributes to log attributes / metric tags

### DIFF
--- a/.chloggen/jade-guiton-dd_expose-scope-attributes.yaml
+++ b/.chloggen/jade-guiton-dd_expose-scope-attributes.yaml
@@ -1,0 +1,17 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'enhancement'
+
+# The name of the component (e.g. pkg/quantile)
+component: pkg/otlp
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Convert OTel instrumentation scope attributes to log attributes / metric tags
+
+# The PR related to this change
+issues: [598]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  For metrics, the conversion is enabled by the WithInstrumentationScopeMetadataAsTags option.

--- a/pkg/otlp/logs/transform_test.go
+++ b/pkg/otlp/logs/transform_test.go
@@ -39,8 +39,9 @@ func TestTranslator(t *testing.T) {
 	ddSp := spanIDToUint64(spanID)
 
 	type args struct {
-		lr  plog.LogRecord
-		res pcommon.Resource
+		lr    plog.LogRecord
+		res   pcommon.Resource
+		scope pcommon.InstrumentationScope
 	}
 	tests := []struct {
 		name string
@@ -57,7 +58,8 @@ func TestTranslator(t *testing.T) {
 					l.SetSeverityNumber(5)
 					return l
 				}(),
-				res: pcommon.NewResource(),
+				res:   pcommon.NewResource(),
+				scope: pcommon.NewInstrumentationScope(),
 			},
 			want: datadogV2.HTTPLogItem{
 				Ddtags:  datadog.PtrString("otel_source:test"),
@@ -84,6 +86,7 @@ func TestTranslator(t *testing.T) {
 					r.Attributes().PutStr(conventions.AttributeServiceName, "otlp_col")
 					return r
 				}(),
+				scope: pcommon.NewInstrumentationScope(),
 			},
 			want: datadogV2.HTTPLogItem{
 				Ddtags:  datadog.PtrString("service:otlp_col,otel_source:test"),
@@ -113,6 +116,7 @@ func TestTranslator(t *testing.T) {
 					r.Attributes().PutStr(conventions.AttributeServiceName, "otlp_col")
 					return r
 				}(),
+				scope: pcommon.NewInstrumentationScope(),
 			},
 			want: datadogV2.HTTPLogItem{
 				Ddtags:  datadog.PtrString("service:otlp_col,foo:bar,otel_source:test"),
@@ -137,10 +141,8 @@ func TestTranslator(t *testing.T) {
 					l.SetSeverityNumber(5)
 					return l
 				}(),
-				res: func() pcommon.Resource {
-					r := pcommon.NewResource()
-					return r
-				}(),
+				res:   pcommon.NewResource(),
+				scope: pcommon.NewInstrumentationScope(),
 			},
 			want: datadogV2.HTTPLogItem{
 				Ddtags:  datadog.PtrString("otel_source:test"),
@@ -166,10 +168,8 @@ func TestTranslator(t *testing.T) {
 					l.SetSeverityNumber(5)
 					return l
 				}(),
-				res: func() pcommon.Resource {
-					r := pcommon.NewResource()
-					return r
-				}(),
+				res:   pcommon.NewResource(),
+				scope: pcommon.NewInstrumentationScope(),
 			},
 			want: datadogV2.HTTPLogItem{
 				Ddtags:  datadog.PtrString("otel_source:test"),
@@ -199,10 +199,8 @@ func TestTranslator(t *testing.T) {
 					l.SetSeverityNumber(5)
 					return l
 				}(),
-				res: func() pcommon.Resource {
-					r := pcommon.NewResource()
-					return r
-				}(),
+				res:   pcommon.NewResource(),
+				scope: pcommon.NewInstrumentationScope(),
 			},
 			want: datadogV2.HTTPLogItem{
 				Ddtags:  datadog.PtrString("otel_source:test"),
@@ -232,10 +230,8 @@ func TestTranslator(t *testing.T) {
 					l.SetSeverityNumber(5)
 					return l
 				}(),
-				res: func() pcommon.Resource {
-					r := pcommon.NewResource()
-					return r
-				}(),
+				res:   pcommon.NewResource(),
+				scope: pcommon.NewInstrumentationScope(),
 			},
 			want: datadogV2.HTTPLogItem{
 				Ddtags:  datadog.PtrString("otel_source:test"),
@@ -265,10 +261,8 @@ func TestTranslator(t *testing.T) {
 					l.SetSeverityNumber(5)
 					return l
 				}(),
-				res: func() pcommon.Resource {
-					r := pcommon.NewResource()
-					return r
-				}(),
+				res:   pcommon.NewResource(),
+				scope: pcommon.NewInstrumentationScope(),
 			},
 			want: datadogV2.HTTPLogItem{
 				Ddtags:  datadog.PtrString("otel_source:test"),
@@ -296,10 +290,8 @@ func TestTranslator(t *testing.T) {
 					l.SetSeverityNumber(5)
 					return l
 				}(),
-				res: func() pcommon.Resource {
-					r := pcommon.NewResource()
-					return r
-				}(),
+				res:   pcommon.NewResource(),
+				scope: pcommon.NewInstrumentationScope(),
 			},
 			want: datadogV2.HTTPLogItem{
 				Ddtags:  datadog.PtrString("otel_source:test"),
@@ -327,10 +319,8 @@ func TestTranslator(t *testing.T) {
 					l.SetSeverityNumber(5)
 					return l
 				}(),
-				res: func() pcommon.Resource {
-					r := pcommon.NewResource()
-					return r
-				}(),
+				res:   pcommon.NewResource(),
+				scope: pcommon.NewInstrumentationScope(),
 			},
 			want: datadogV2.HTTPLogItem{
 				Ddtags:  datadog.PtrString("otel_source:test"),
@@ -362,10 +352,8 @@ func TestTranslator(t *testing.T) {
 					l.Body().SetStr("This is log")
 					return l
 				}(),
-				res: func() pcommon.Resource {
-					r := pcommon.NewResource()
-					return r
-				}(),
+				res:   pcommon.NewResource(),
+				scope: pcommon.NewInstrumentationScope(),
 			},
 			want: datadogV2.HTTPLogItem{
 				Ddtags:  datadog.PtrString("otel_source:test"),
@@ -397,10 +385,8 @@ func TestTranslator(t *testing.T) {
 					l.Body().SetStr("This is log")
 					return l
 				}(),
-				res: func() pcommon.Resource {
-					r := pcommon.NewResource()
-					return r
-				}(),
+				res:   pcommon.NewResource(),
+				scope: pcommon.NewInstrumentationScope(),
 			},
 			want: datadogV2.HTTPLogItem{
 				Ddtags:  datadog.PtrString("otel_source:test"),
@@ -433,6 +419,7 @@ func TestTranslator(t *testing.T) {
 					r.Attributes().PutStr("key", "val")
 					return r
 				}(),
+				scope: pcommon.NewInstrumentationScope(),
 			},
 			want: datadogV2.HTTPLogItem{
 				Ddtags:  datadog.PtrString("service:otlp_col,otel_source:test"),
@@ -462,6 +449,7 @@ func TestTranslator(t *testing.T) {
 					r.Attributes().PutStr("service", "otlp_col")
 					return r
 				}(),
+				scope: pcommon.NewInstrumentationScope(),
 			},
 			want: datadogV2.HTTPLogItem{
 				Ddtags:  datadog.PtrString("service:otlp_col,otel_source:test"),
@@ -497,10 +485,8 @@ func TestTranslator(t *testing.T) {
 					)
 					return l
 				}(),
-				res: func() pcommon.Resource {
-					r := pcommon.NewResource()
-					return r
-				}(),
+				res:   pcommon.NewResource(),
+				scope: pcommon.NewInstrumentationScope(),
 			},
 			want: datadogV2.HTTPLogItem{
 				Ddtags:  datadog.PtrString("otel_source:test"),
@@ -521,10 +507,8 @@ func TestTranslator(t *testing.T) {
 					l.Attributes().FromRaw(nil)
 					return l
 				}(),
-				res: func() pcommon.Resource {
-					r := pcommon.NewResource()
-					return r
-				}(),
+				res:   pcommon.NewResource(),
+				scope: pcommon.NewInstrumentationScope(),
 			},
 			want: datadogV2.HTTPLogItem{
 				Ddtags:  datadog.PtrString("otel_source:test"),
@@ -571,10 +555,8 @@ func TestTranslator(t *testing.T) {
 					)
 					return l
 				}(),
-				res: func() pcommon.Resource {
-					r := pcommon.NewResource()
-					return r
-				}(),
+				res:   pcommon.NewResource(),
+				scope: pcommon.NewInstrumentationScope(),
 			},
 			want: datadogV2.HTTPLogItem{
 				Ddtags:  datadog.PtrString("otel_source:test"),
@@ -595,10 +577,8 @@ func TestTranslator(t *testing.T) {
 					l.SetSeverityNumber(5)
 					return l
 				}(),
-				res: func() pcommon.Resource {
-					r := pcommon.NewResource()
-					return r
-				}(),
+				res:   pcommon.NewResource(),
+				scope: pcommon.NewInstrumentationScope(),
 			},
 			want: datadogV2.HTTPLogItem{
 				Ddtags:  datadog.PtrString("otel_source:test"),
@@ -608,6 +588,35 @@ func TestTranslator(t *testing.T) {
 					otelSeverityNumber: "5",
 					ddTimestamp:        "2023-11-20T16:55:03.397Z",
 					otelTimestamp:      "1700499303397000000",
+				},
+			},
+		},
+		{
+			name: "scope attributes",
+			args: args{
+				lr: func() plog.LogRecord {
+					l := plog.NewLogRecord()
+					l.Body().SetStr("hello world")
+					l.SetSeverityNumber(5)
+					return l
+				}(),
+				res: pcommon.NewResource(),
+				scope: func() pcommon.InstrumentationScope {
+					s := pcommon.NewInstrumentationScope()
+					sa := s.Attributes()
+					sa.PutStr("otelcol.component.id", "otlp")
+					sa.PutStr("otelcol.component.kind", "Receiver")
+					return s
+				}(),
+			},
+			want: datadogV2.HTTPLogItem{
+				Ddtags:  datadog.PtrString("otel_source:test"),
+				Message: *datadog.PtrString("hello world"),
+				AdditionalProperties: map[string]interface{}{
+					"status":                 "debug",
+					otelSeverityNumber:       "5",
+					"otelcol.component.id":   "otlp",
+					"otelcol.component.kind": "Receiver",
 				},
 			},
 		},
@@ -625,7 +634,9 @@ func TestTranslator(t *testing.T) {
 			logs := plog.NewLogs()
 			rl := logs.ResourceLogs().AppendEmpty()
 			tt.args.res.MoveTo(rl.Resource())
-			tt.args.lr.CopyTo(rl.ScopeLogs().AppendEmpty().LogRecords().AppendEmpty())
+			sl := rl.ScopeLogs().AppendEmpty()
+			tt.args.scope.MoveTo(sl.Scope())
+			tt.args.lr.CopyTo(sl.LogRecords().AppendEmpty())
 
 			payloads := translator.MapLogs(context.Background(), logs, nil)
 			require.Len(t, payloads, 1)

--- a/pkg/otlp/logs/translator.go
+++ b/pkg/otlp/logs/translator.go
@@ -76,6 +76,7 @@ func (t *Translator) MapLogs(ctx context.Context, ld plog.Logs, hostFromAttribut
 		for j := 0; j < sls.Len(); j++ {
 			sl := sls.At(j)
 			lsl := sl.LogRecords()
+			scope := sl.Scope()
 			// iterate over Logs
 			for k := 0; k < lsl.Len(); k++ {
 				log := lsl.At(k)
@@ -90,7 +91,7 @@ func (t *Translator) MapLogs(ctx context.Context, ld plog.Logs, hostFromAttribut
 					}
 				}
 
-				payload := transform(log, host, service, res, t.set.Logger)
+				payload := transform(log, host, service, res, scope, t.set.Logger)
 				ddtags := payload.GetDdtags()
 				if ddtags != "" {
 					payload.SetDdtags(ddtags + "," + t.otelTag)

--- a/pkg/otlp/metrics/internal/instrumentationscope/metadata.go
+++ b/pkg/otlp/metrics/internal/instrumentationscope/metadata.go
@@ -25,11 +25,14 @@ const (
 	instrumentationScopeVersionTag = "instrumentation_scope_version"
 )
 
-// TagsFromInstrumentationScopeMetadata takes the name and version of
+// TagsFromInstrumentationScopeMetadata takes the name, version, and attributes of
 // the instrumentation scope and converts them to Datadog tags.
 func TagsFromInstrumentationScopeMetadata(il pcommon.InstrumentationScope) []string {
-	return []string{
-		utils.FormatKeyValueTag(instrumentationScopeTag, il.Name()),
-		utils.FormatKeyValueTag(instrumentationScopeVersionTag, il.Version()),
+	tags := make([]string, 0, 2+il.Attributes().Len())
+	tags = append(tags, utils.FormatKeyValueTag(instrumentationScopeTag, il.Name()))
+	tags = append(tags, utils.FormatKeyValueTag(instrumentationScopeVersionTag, il.Version()))
+	for k, v := range il.Attributes().Range {
+		tags = append(tags, utils.FormatKeyValueTag(k, v.AsString()))
 	}
+	return tags
 }

--- a/pkg/otlp/metrics/internal/instrumentationscope/metadata_test.go
+++ b/pkg/otlp/metrics/internal/instrumentationscope/metadata_test.go
@@ -26,18 +26,51 @@ func TestTagsFromInstrumentationScopeMetadata(t *testing.T) {
 	tests := []struct {
 		name         string
 		version      string
+		attrs        map[string]string
 		expectedTags []string
 	}{
-		{"test-il", "1.0.0", []string{fmt.Sprintf("%s:%s", instrumentationScopeTag, "test-il"), fmt.Sprintf("%s:%s", instrumentationScopeVersionTag, "1.0.0")}},
-		{"test-il", "", []string{fmt.Sprintf("%s:%s", instrumentationScopeTag, "test-il"), fmt.Sprintf("%s:%s", instrumentationScopeVersionTag, "n/a")}},
-		{"", "1.0.0", []string{fmt.Sprintf("%s:%s", instrumentationScopeTag, "n/a"), fmt.Sprintf("%s:%s", instrumentationScopeVersionTag, "1.0.0")}},
-		{"", "", []string{fmt.Sprintf("%s:%s", instrumentationScopeTag, "n/a"), fmt.Sprintf("%s:%s", instrumentationScopeVersionTag, "n/a")}},
+		{
+			"test-il", "1.0.0",
+			nil,
+			[]string{fmt.Sprintf("%s:%s", instrumentationScopeTag, "test-il"), fmt.Sprintf("%s:%s", instrumentationScopeVersionTag, "1.0.0")},
+		},
+		{
+			"test-il", "",
+			nil,
+			[]string{fmt.Sprintf("%s:%s", instrumentationScopeTag, "test-il"), fmt.Sprintf("%s:%s", instrumentationScopeVersionTag, "n/a")},
+		},
+		{
+			"", "1.0.0",
+			nil,
+			[]string{fmt.Sprintf("%s:%s", instrumentationScopeTag, "n/a"), fmt.Sprintf("%s:%s", instrumentationScopeVersionTag, "1.0.0")},
+		},
+		{
+			"", "",
+			nil,
+			[]string{fmt.Sprintf("%s:%s", instrumentationScopeTag, "n/a"), fmt.Sprintf("%s:%s", instrumentationScopeVersionTag, "n/a")},
+		},
+		{
+			"go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc", "0.60.0",
+			map[string]string{
+				"otelcol.component.id":   "otlp",
+				"otelcol.component.kind": "Receiver",
+			},
+			[]string{
+				fmt.Sprintf("%s:%s", instrumentationScopeTag, "go.opentelemetry.io/contrib/instrumentation/google.golang.org/grpc/otelgrpc"),
+				fmt.Sprintf("%s:%s", instrumentationScopeVersionTag, "0.60.0"),
+				"otelcol.component.id:otlp",
+				"otelcol.component.kind:Receiver",
+			},
+		},
 	}
 
 	for _, testInstance := range tests {
 		il := pcommon.NewInstrumentationScope()
 		il.SetName(testInstance.name)
 		il.SetVersion(testInstance.version)
+		for k, v := range testInstance.attrs {
+			il.Attributes().PutStr(k, v)
+		}
 		tags := TagsFromInstrumentationScopeMetadata(il)
 
 		assert.ElementsMatch(t, testInstance.expectedTags, tags)


### PR DESCRIPTION
### What does this PR do?

Adds support for OTel instrumentation scope attributes in `pkg/otlp/logs` and `pkg/otlp/metrics`, by converting them to log attributes and metric tags. In the latter case, this is locked behind the `WithInstrumentationScopeMetadataAsTags` option, which corresponds to the `instrumentation_scope_metadata_as_tags` setting in the Datadog exporter (but currently nothing in the serializerexporter, I will fix that in a separate PR).

### Motivation

Since last week's release, the OTel Collector has a feature gate which enables injecting scope attributes in its internal telemetry to clearly identify which Collector component emitted it. This makes it important for Datadog to be able to read and display these attributes to the user.

### Describe how you validated your changes

I added test cases to both parts of the code to validate the basic translation behavior.