### PR TITLE
Optimizing memory usage in exponential histogram to Sketch conversion

### DIFF
--- a/.chloggen/fix-memory-leak-sketch-transform.yaml
+++ b/.chloggen/fix-memory-leak-sketch-transform.yaml
@@ -1,0 +1,10 @@
+change_type: 'enhancement'
+
+component: "pkg/quantile"
+
+note: "Improve performance of conversion from DDSketch to Sketch for both allocations and CPU usage."
+
+issues: [602]
+
+subtext: |
+  This optimization reduces memory allocations and garbage collection pressure during DDSketch to Sketch conversions by introducing object pooling for KeyCount slices, DenseStore objects, and bin lists. These changes significantly improve performance in high-throughput scenarios, achieving up to 92% reduction in memory usage and 16% faster conversions, as demonstrated by benchmark results.

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,10 @@ install-tools:
 	cd $(TOOLS_MOD_DIR) && go install gotest.tools/gotestsum
 	cd $(TOOLS_MOD_DIR)/generate-license-file && go install .
 
+GOPATH?=$(shell go env GOPATH)
+GOBIN?=$(GOPATH)/bin
+GOLANGCI_LINT_BIN?=$(GOBIN)/golangci-lint
+
 FILENAME?=$(shell git branch --show-current).yaml
 .PHONY: chlog-new
 chlog-new:
@@ -64,7 +68,7 @@ test-junit:
 # Use 'make lint OPTS="--fix"' to autofix issues.
 .PHONY: lint
 lint:
-	@$(MAKE) for-all CMD="golangci-lint run ./... $(OPTS)"
+	@$(MAKE) for-all CMD="$(GOLANGCI_LINT_BIN) run ./... $(OPTS)"
 
 # Generate licenses file for compliance. 
 .PHONY: gen-licenses

--- a/pkg/quantile/pool.go
+++ b/pkg/quantile/pool.go
@@ -7,6 +7,8 @@ package quantile
 
 import (
 	"sync"
+
+	"github.com/DataDog/sketches-go/ddsketch/store"
 )
 
 const (
@@ -64,4 +66,54 @@ func getOverflowList() []bin {
 
 func putOverflowList(a []bin) {
 	overflowListPool.Put(&a)
+}
+
+var floatKeyCountPool = sync.Pool{
+	New: func() interface{} {
+		a := make([]floatKeyCount, 0, defaultBinListSize)
+		return &a
+	},
+}
+
+func getFloatKeyCountList() []floatKeyCount {
+	a := *(floatKeyCountPool.Get().(*[]floatKeyCount))
+	return a[:0]
+}
+
+func putFloatKeyCountList(a []floatKeyCount) {
+	if cap(a) >= defaultBinListSize {
+		floatKeyCountPool.Put(&a)
+	}
+}
+
+var keyCountPool = sync.Pool{
+	New: func() interface{} {
+		a := make([]KeyCount, 0, defaultBinListSize)
+		return &a
+	},
+}
+
+func getKeyCountList() []KeyCount {
+	a := *(keyCountPool.Get().(*[]KeyCount))
+	return a[:0]
+}
+
+func putKeyCountList(a []KeyCount) {
+	if cap(a) >= defaultBinListSize {
+		keyCountPool.Put(&a)
+	}
+}
+
+var denseStorePool = sync.Pool{
+	New: func() interface{} {
+		return store.NewDenseStore()
+	},
+}
+
+func getDenseStore() store.Store {
+	return denseStorePool.Get().(store.Store)
+}
+
+func putDenseStore(s store.Store) {
+	denseStorePool.Put(s)
 }


### PR DESCRIPTION
### What does this PR do?

This PR introduces memory allocation optimizations in the DDSketch to Sketch conversion process, resulting in reduced GC pressure during high-throughput scenarios.

## Changes

1. **Object Pooling with `sync.Pool`**:
   - Added pools for `KeyCount` slices and `DenseStore` objects to reduce allocation overhead
   - Added pool for bin list ([]bin) (the main offender)
   - Implemented getter/putter functions to manage pooled resources

I reused the `pool.go` file here, let me know if this is okay or if I should keep the new pools in the same file.

3. **Build System Enhancements**:
   - Updated Makefile to use configurable path for golangci-lint
   - Added GOPATH and GOBIN variables for better environment compatibility

I can revert this change, but in my local machine I had problems where my local installation of golanglint-ci was taking precedence over the binary in GOBIN.

## Benefits

These changes significantly reduce memory allocations during DDSketch to Sketch conversion operations, particularly in high-throughput scenarios where many conversions happen in succession. By reusing slice and store objects, we avoid repeated allocations and subsequent garbage collection.

```
goos: darwin
goarch: arm64
pkg: github.com/DataDog/opentelemetry-mapping-go/pkg/quantile
cpu: Apple M3 Pro
                             │ /tmp/old-code.txt │        /tmp/v2-new-code.txt         │
                             │      sec/op       │    sec/op     vs base               │
DDSketchConversion/Small-11         43.10µ ± 13%   37.02µ ±  1%  -14.10% (p=0.002 n=6)
DDSketchConversion/Medium-11        45.46µ ±  8%   37.13µ ± 13%  -18.32% (p=0.002 n=6)
DDSketchConversion/Large-11         45.10µ ± 18%   37.06µ ±  2%  -17.83% (p=0.002 n=6)
geomean                             44.54µ         37.07µ        -16.77%

                             │ /tmp/old-code.txt │        /tmp/v2-new-code.txt         │
                             │       B/op        │     B/op      vs base               │
DDSketchConversion/Small-11        174.90Ki ± 0%   13.60Ki ± 0%  -92.22% (p=0.002 n=6)
DDSketchConversion/Medium-11       174.91Ki ± 0%   13.61Ki ± 1%  -92.22% (p=0.002 n=6)
DDSketchConversion/Large-11        174.93Ki ± 0%   13.61Ki ± 0%  -92.22% (p=0.002 n=6)
geomean                             174.9Ki        13.61Ki       -92.22%

                             │ /tmp/old-code.txt │       /tmp/v2-new-code.txt        │
                             │     allocs/op     │ allocs/op   vs base               │
DDSketchConversion/Small-11           33.00 ± 0%   37.00 ± 0%  +12.12% (p=0.002 n=6)
DDSketchConversion/Medium-11          33.00 ± 0%   37.00 ± 0%  +12.12% (p=0.002 n=6)
DDSketchConversion/Large-11           33.00 ± 0%   37.00 ± 0%  +12.12% (p=0.002 n=6)
geomean                               33.00        37.00       +12.12%

```

## Testing

All tests pass with the new implementation, confirming that the optimization maintains correctness while improving resource usage.


### Motivation

While analyzing memory profiles from our production application, we identified the DDSketch conversion path as a significant contributor to memory pressure. Profiling revealed that frequent allocations of KeyCount slices and DenseStore objects during high-throughput metric processing were causing increased GC activity and memory usage spikes. This optimization addresses these specific hotspots to improve overall application performance and resource utilization.

![image](https://github.com/user-attachments/assets/48bac1ab-3b40-4722-bc11-c64e616b7e73)


