### PR TITLE
Send hostmap on new host

### DIFF
--- a/.chloggen/mackjmr_send-host-metadata-new-host.yaml
+++ b/.chloggen/mackjmr_send-host-metadata-new-host.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component (e.g. pkg/quantile)
+component: pkg/infradata
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Send host meta on new hosts.
+
+# The PR related to this change
+issues: [652]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/pkg/inframetadata/internal/hostmap/hostmap.go
+++ b/pkg/inframetadata/internal/hostmap/hostmap.go
@@ -303,7 +303,7 @@ func (m *HostMap) Update(host string, res pcommon.Resource) (changed bool, md pa
 	}
 
 	m.hosts[host] = md
-	changed = changed && found
+	changed = changed && !found
 	return
 }
 

--- a/pkg/inframetadata/internal/hostmap/hostmap_test.go
+++ b/pkg/inframetadata/internal/hostmap/hostmap_test.go
@@ -170,7 +170,7 @@ func TestUpdate(t *testing.T) {
 				conventions.AttributeDeploymentEnvironment: "prod",
 			},
 			metric:          BuildMetric[int64](metricSystemCPUPhysicalCount, 32),
-			expectedChanged: false,
+			expectedChanged: true,
 		},
 		{
 			// Same as #1, but missing some attributes
@@ -205,7 +205,7 @@ func TestUpdate(t *testing.T) {
 				"datadog.host.tag.foo":                     "baz",                                                 // changed
 				conventions.AttributeDeploymentEnvironment: "prod",
 			},
-			expectedChanged: true,
+			expectedChanged: false,
 			expectedErrs:    []string{"\"os.description\" has type \"Bool\", expected type \"Str\" instead"},
 		},
 		{
@@ -240,6 +240,7 @@ func TestUpdate(t *testing.T) {
 				conventions.AttributeHostArch:      conventions.AttributeHostArchARM64,
 				"deployment.environment.name":      "staging",
 			},
+			expectedChanged: true,
 		},
 	}
 


### PR DESCRIPTION
### What does this PR do?

This fixes a bug when host meta was not sent for new hosts, which means if the host never changed, the host meta would never be sent.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

