### PR TITLE
[OTEL-2649] Fix cumulative-to-delta conversion to avoid spikes on translator restart

### DIFF
--- a/.chloggen/jade-guiton-dd_fix-cumul-to-delta-initial-value.yaml
+++ b/.chloggen/jade-guiton-dd_fix-cumul-to-delta-initial-value.yaml
@@ -1,0 +1,17 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: 'bug_fix'
+
+# The name of the component (e.g. pkg/quantile)
+component: pkg/otlp/metrics
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Fix automatic intial point dropping when converting cumulative monotonic sum metrics
+
+# The PR related to this change
+issues: [654]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  This may fix issues with large spikes on Agent/Collector restarts.

--- a/pkg/otlp/metrics/metrics_translator.go
+++ b/pkg/otlp/metrics/metrics_translator.go
@@ -178,8 +178,8 @@ func (t *Translator) mapNumberMetrics(
 var startTime = uint64(time.Now().UnixNano())
 
 // getProcessStartTime returns the start time of the Agent process in seconds since epoch
-func getProcessStartTime() int {
-	return int(startTime / 1_000_000_000)
+func getProcessStartTime() uint64 {
+	return startTime / 1_000_000_000
 }
 
 // getProcessStartTimeNano returns the start time of the Agent process in nanoseconds since epoch

--- a/pkg/otlp/metrics/metrics_translator.go
+++ b/pkg/otlp/metrics/metrics_translator.go
@@ -175,10 +175,15 @@ func (t *Translator) mapNumberMetrics(
 
 // TODO(songy23): consider changing this to a Translator start time that must be initialized
 // if the package-level variable causes any issue.
-var startTime = uint64(time.Now().Unix())
+var startTime = uint64(time.Now().UnixNano())
 
 // getProcessStartTime returns the start time of the Agent process in seconds since epoch
 func getProcessStartTime() uint64 {
+	return startTime / 1_000_000_000
+}
+
+// getProcessStartTime returns the start time of the Agent process in nanoseconds since epoch
+func getProcessStartTimeNano() uint64 {
 	return startTime
 }
 
@@ -187,7 +192,7 @@ func getProcessStartTime() uint64 {
 func (t *Translator) shouldConsumeInitialValue(startTs, ts uint64) bool {
 	switch t.cfg.InitialCumulMonoValueMode {
 	case InitialCumulMonoValueModeAuto:
-		if getProcessStartTime() < startTs && startTs != ts {
+		if getProcessStartTimeNano() < startTs && startTs != ts {
 			// Report the first value if the timeseries started after the Datadog Agent process started.
 			return true
 		}

--- a/pkg/otlp/metrics/metrics_translator.go
+++ b/pkg/otlp/metrics/metrics_translator.go
@@ -178,8 +178,8 @@ func (t *Translator) mapNumberMetrics(
 var startTime = uint64(time.Now().UnixNano())
 
 // getProcessStartTime returns the start time of the Agent process in seconds since epoch
-func getProcessStartTime() uint64 {
-	return startTime / 1_000_000_000
+func getProcessStartTime() int {
+	return int(startTime / 1_000_000_000)
 }
 
 // getProcessStartTime returns the start time of the Agent process in nanoseconds since epoch

--- a/pkg/otlp/metrics/metrics_translator.go
+++ b/pkg/otlp/metrics/metrics_translator.go
@@ -182,7 +182,7 @@ func getProcessStartTime() int {
 	return int(startTime / 1_000_000_000)
 }
 
-// getProcessStartTime returns the start time of the Agent process in nanoseconds since epoch
+// getProcessStartTimeNano returns the start time of the Agent process in nanoseconds since epoch
 func getProcessStartTimeNano() uint64 {
 	return startTime
 }

--- a/pkg/otlp/metrics/metrics_translator_test.go
+++ b/pkg/otlp/metrics/metrics_translator_test.go
@@ -984,10 +984,10 @@ func buildIntPoints(startTs int, deltas []int64) pmetric.NumberDataPointSlice {
 	return slice
 }
 
-// Regression Test: Check that initial point drop behavior based on the value of
+// Regression Test: Check initial point drop behavior based on the value of
 // InitialCumulMonoValueMode and whether the metric series started before or after the Agent.
 // Notably, we want to make sure that the "auto" value drops the initial point iff the series
-// started before the Agent.
+// started before the metrics translator.
 func TestInitialCumulMonoValueMode(t *testing.T) {
 	ctx := context.Background()
 

--- a/pkg/otlp/metrics/metrics_translator_test.go
+++ b/pkg/otlp/metrics/metrics_translator_test.go
@@ -464,7 +464,7 @@ func TestMapIntMonotonicWithRebootBeginningOfSlice(t *testing.T) {
 	t.Run("diff", func(t *testing.T) {
 		tr := newTranslator(t, zap.NewNop())
 		dims := &Dimensions{name: exampleDims.name, host: fallbackHostname}
-		startTs := int(getProcessStartTime()) + 1
+		startTs := getProcessStartTime() + 1
 		md := pmetric.NewMetrics()
 		met := md.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
 		met.SetName(dims.name)
@@ -505,7 +505,7 @@ func TestMapIntMonotonicWithRebootBeginningOfSlice(t *testing.T) {
 	t.Run("rate", func(t *testing.T) {
 		tr := newTranslator(t, zap.NewNop())
 		dims := &Dimensions{name: rateAsGaugeDims.name, host: fallbackHostname}
-		startTs := int(getProcessStartTime()) + 1
+		startTs := getProcessStartTime() + 1
 		md := pmetric.NewMetrics()
 		met := md.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
 		met.SetName(dims.name)
@@ -547,7 +547,7 @@ func TestMapIntMonotonicWithRebootBeginningOfSlice(t *testing.T) {
 // to the timestamp of previous point received is dropped.
 func TestMapIntMonotonicDropPointPointWithinSlice(t *testing.T) {
 	t.Run("equal", func(t *testing.T) {
-		startTs := int(getProcessStartTime()) + 1
+		startTs := getProcessStartTime() + 1
 		md := pmetric.NewMetrics()
 		met := md.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
 		met.SetName(exampleDims.name)
@@ -589,7 +589,7 @@ func TestMapIntMonotonicDropPointPointWithinSlice(t *testing.T) {
 	})
 
 	t.Run("equal-rate", func(t *testing.T) {
-		startTs := int(getProcessStartTime()) + 1
+		startTs := getProcessStartTime() + 1
 		md := pmetric.NewMetrics()
 		met := md.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
 		met.SetName(rateAsGaugeDims.name)
@@ -631,7 +631,7 @@ func TestMapIntMonotonicDropPointPointWithinSlice(t *testing.T) {
 	})
 
 	t.Run("older", func(t *testing.T) {
-		startTs := int(getProcessStartTime()) + 1
+		startTs := getProcessStartTime() + 1
 		md := pmetric.NewMetrics()
 		met := md.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
 		met.SetName(exampleDims.name)
@@ -673,7 +673,7 @@ func TestMapIntMonotonicDropPointPointWithinSlice(t *testing.T) {
 	})
 
 	t.Run("older-rate", func(t *testing.T) {
-		startTs := int(getProcessStartTime()) + 1
+		startTs := getProcessStartTime() + 1
 		md := pmetric.NewMetrics()
 		met := md.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
 		met.SetName(rateAsGaugeDims.name)
@@ -721,7 +721,7 @@ func TestMapIntMonotonicDropPointPointBeginningOfSlice(t *testing.T) {
 	t.Run("equal", func(t *testing.T) {
 		tr := newTranslator(t, zap.NewNop())
 		dims := &Dimensions{name: exampleDims.name, host: fallbackHostname}
-		startTs := int(getProcessStartTime()) + 1
+		startTs := getProcessStartTime() + 1
 		md := pmetric.NewMetrics()
 		met := md.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
 		met.SetName(dims.name)
@@ -761,7 +761,7 @@ func TestMapIntMonotonicDropPointPointBeginningOfSlice(t *testing.T) {
 	t.Run("equal-rate", func(t *testing.T) {
 		tr := newTranslator(t, zap.NewNop())
 		dims := &Dimensions{name: rateAsGaugeDims.name, host: fallbackHostname}
-		startTs := int(getProcessStartTime()) + 1
+		startTs := getProcessStartTime() + 1
 		md := pmetric.NewMetrics()
 		met := md.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
 		met.SetName(dims.name)
@@ -801,7 +801,7 @@ func TestMapIntMonotonicDropPointPointBeginningOfSlice(t *testing.T) {
 	t.Run("older", func(t *testing.T) {
 		tr := newTranslator(t, zap.NewNop())
 		dims := &Dimensions{name: exampleDims.name, host: fallbackHostname}
-		startTs := int(getProcessStartTime()) + 1
+		startTs := getProcessStartTime() + 1
 		md := pmetric.NewMetrics()
 		met := md.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
 		met.SetName(dims.name)
@@ -841,7 +841,7 @@ func TestMapIntMonotonicDropPointPointBeginningOfSlice(t *testing.T) {
 	t.Run("older-rate", func(t *testing.T) {
 		tr := newTranslator(t, zap.NewNop())
 		dims := &Dimensions{name: rateAsGaugeDims.name, host: fallbackHostname}
-		startTs := int(getProcessStartTime()) + 1
+		startTs := getProcessStartTime() + 1
 		md := pmetric.NewMetrics()
 		met := md.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
 		met.SetName(dims.name)
@@ -885,7 +885,7 @@ func TestMapIntMonotonicReportFirstValue(t *testing.T) {
 	tr := newTranslator(t, zap.NewNop())
 	consumer := &mockFullConsumer{}
 	rmt, _ := tr.MapMetrics(ctx, createTestIntCumulativeMonotonicMetrics(false, exampleDims), consumer, nil)
-	startTs := int(getProcessStartTime()) + 1
+	startTs := getProcessStartTime() + 1
 	assert.ElementsMatch(t,
 		consumer.metrics,
 		[]metric{
@@ -902,7 +902,7 @@ func TestMapIntMonotonicRateDontReportFirstValue(t *testing.T) {
 	tr := newTranslator(t, zap.NewNop())
 	consumer := &mockFullConsumer{}
 	rmt, _ := tr.MapMetrics(ctx, createTestIntCumulativeMonotonicMetrics(false, rateAsGaugeDims), consumer, nil)
-	startTs := int(getProcessStartTime()) + 1
+	startTs := getProcessStartTime() + 1
 	assert.ElementsMatch(t,
 		consumer.metrics,
 		[]metric{
@@ -936,7 +936,7 @@ func TestMapIntMonotonicReportDiffForFirstValue(t *testing.T) {
 	tr := newTranslator(t, zap.NewNop())
 	consumer := &mockFullConsumer{}
 	dims := &Dimensions{name: exampleDims.name, host: fallbackHostname}
-	startTs := int(getProcessStartTime()) + 1
+	startTs := getProcessStartTime() + 1
 	// Add an entry to the cache about the timeseries, in this case we send the diff (9) rather than the first value (10).
 	tr.prevPts.MonotonicDiff(dims, uint64(seconds(startTs)), uint64(seconds(startTs+1)), 1)
 	rmt, _ := tr.MapMetrics(ctx, createTestIntCumulativeMonotonicMetrics(false, exampleDims), consumer, nil)
@@ -956,7 +956,7 @@ func TestMapIntMonotonicReportRateForFirstValue(t *testing.T) {
 	tr := newTranslator(t, zap.NewNop())
 	consumer := &mockFullConsumer{}
 	dims := &Dimensions{name: rateAsGaugeDims.name, host: fallbackHostname}
-	startTs := int(getProcessStartTime()) + 1
+	startTs := getProcessStartTime() + 1
 	// Add an entry to the cache about the timeseries, in this case we send the rate (10-1)/(startTs+2-startTs+1) rather than the first value (10).
 	tr.prevPts.MonotonicDiff(dims, uint64(seconds(startTs)), uint64(seconds(startTs+1)), 1)
 	rmt, _ := tr.MapMetrics(ctx, createTestIntCumulativeMonotonicMetrics(false, rateAsGaugeDims), consumer, nil)
@@ -1037,7 +1037,7 @@ func TestMapRuntimeMetricsHasMapping(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	startTs := int(getProcessStartTime()) + 1
+	startTs := getProcessStartTime() + 1
 	assert.ElementsMatch(t,
 		consumer.metrics,
 		[]metric{
@@ -1063,7 +1063,7 @@ func TestMapRuntimeMetricsHasMappingCollector(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	startTs := int(getProcessStartTime()) + 1
+	startTs := getProcessStartTime() + 1
 	assert.ElementsMatch(t,
 		consumer.metrics,
 		[]metric{
@@ -1092,7 +1092,7 @@ func TestMapSystemMetricsRenamedWithOTelPrefix(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	startTs := int(getProcessStartTime()) + 1
+	startTs := getProcessStartTime() + 1
 	// Ensure datadog metrics are not created from system.cpu.utilization (ex: system.cpu.idle, system.cpu.system, etc)
 	// Ensure otel.* prefix is added to system and process metrics
 	// Ensure otel.* prefix is not added to jvm or go runtime metrics
@@ -1130,7 +1130,7 @@ func TestMapSumRuntimeMetricWithAttributesHasMapping(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	startTs := int(getProcessStartTime()) + 1
+	startTs := getProcessStartTime() + 1
 	assert.ElementsMatch(t,
 		consumer.metrics,
 		[]metric{
@@ -1153,7 +1153,7 @@ func TestMapSumRuntimeMetricWithAttributesHasMappingCollector(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	startTs := int(getProcessStartTime()) + 1
+	startTs := getProcessStartTime() + 1
 	assert.ElementsMatch(t,
 		consumer.metrics,
 		[]metric{
@@ -1176,7 +1176,7 @@ func TestMapGaugeRuntimeMetricWithAttributesHasMapping(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	startTs := int(getProcessStartTime()) + 1
+	startTs := getProcessStartTime() + 1
 	assert.ElementsMatch(t,
 		consumer.metrics,
 		[]metric{
@@ -1196,7 +1196,7 @@ func TestMapHistogramRuntimeMetricHasMapping(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	startTs := int(getProcessStartTime()) + 1
+	startTs := getProcessStartTime() + 1
 	assert.ElementsMatch(t,
 		consumer.metrics,
 		[]metric{
@@ -1225,7 +1225,7 @@ func TestMapHistogramRuntimeMetricWithAttributesHasMapping(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	startTs := int(getProcessStartTime()) + 1
+	startTs := getProcessStartTime() + 1
 	assert.ElementsMatch(t,
 		consumer.metrics,
 		[]metric{
@@ -1257,7 +1257,7 @@ func TestMapRuntimeMetricWithTwoAttributesHasMapping(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	startTs := int(getProcessStartTime()) + 1
+	startTs := getProcessStartTime() + 1
 	assert.ElementsMatch(t,
 		consumer.metrics,
 		[]metric{
@@ -1284,7 +1284,7 @@ func TestMapRuntimeMetricWithTwoAttributesMultipleDataPointsHasMapping(t *testin
 	if err != nil {
 		t.Fatal(err)
 	}
-	startTs := int(getProcessStartTime()) + 1
+	startTs := getProcessStartTime() + 1
 	assert.ElementsMatch(t,
 		consumer.metrics,
 		[]metric{
@@ -1354,7 +1354,7 @@ func TestMapGaugeRuntimeMetricWithInvalidAttributes(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	startTs := int(getProcessStartTime()) + 1
+	startTs := getProcessStartTime() + 1
 	assert.ElementsMatch(t,
 		consumer.metrics,
 		[]metric{
@@ -1373,7 +1373,7 @@ func TestMapRuntimeMetricsNoMapping(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	startTs := int(getProcessStartTime()) + 1
+	startTs := getProcessStartTime() + 1
 	assert.ElementsMatch(t,
 		consumer.metrics,
 		[]metric{
@@ -1393,7 +1393,7 @@ func TestMapSystemMetrics(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	startTs := int(getProcessStartTime()) + 1
+	startTs := getProcessStartTime() + 1
 	assert.ElementsMatch(t,
 		consumer.metrics,
 		[]metric{
@@ -1588,7 +1588,7 @@ func TestMapDoubleMonotonicWithRebootBeginningOfSlice(t *testing.T) {
 	t.Run("diff", func(t *testing.T) {
 		tr := newTranslator(t, zap.NewNop())
 		dims := &Dimensions{name: exampleDims.name, host: fallbackHostname}
-		startTs := int(getProcessStartTime()) + 1
+		startTs := getProcessStartTime() + 1
 		md := pmetric.NewMetrics()
 		met := md.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
 		met.SetName(dims.name)
@@ -1629,7 +1629,7 @@ func TestMapDoubleMonotonicWithRebootBeginningOfSlice(t *testing.T) {
 	t.Run("rate", func(t *testing.T) {
 		tr := newTranslator(t, zap.NewNop())
 		dims := &Dimensions{name: rateAsGaugeDims.name, host: fallbackHostname}
-		startTs := int(getProcessStartTime()) + 1
+		startTs := getProcessStartTime() + 1
 		md := pmetric.NewMetrics()
 		met := md.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
 		met.SetName(dims.name)
@@ -1672,7 +1672,7 @@ func TestMapDoubleMonotonicWithRebootBeginningOfSlice(t *testing.T) {
 // to the timestamp of previous point received is dropped.
 func TestMapDoubleMonotonicDropPointPointWithinSlice(t *testing.T) {
 	t.Run("equal", func(t *testing.T) {
-		startTs := int(getProcessStartTime()) + 1
+		startTs := getProcessStartTime() + 1
 		md := pmetric.NewMetrics()
 		met := md.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
 		met.SetName(exampleDims.name)
@@ -1714,7 +1714,7 @@ func TestMapDoubleMonotonicDropPointPointWithinSlice(t *testing.T) {
 	})
 
 	t.Run("equal-rate", func(t *testing.T) {
-		startTs := int(getProcessStartTime()) + 1
+		startTs := getProcessStartTime() + 1
 		md := pmetric.NewMetrics()
 		met := md.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
 		met.SetName(rateAsGaugeDims.name)
@@ -1756,7 +1756,7 @@ func TestMapDoubleMonotonicDropPointPointWithinSlice(t *testing.T) {
 	})
 
 	t.Run("older", func(t *testing.T) {
-		startTs := int(getProcessStartTime()) + 1
+		startTs := getProcessStartTime() + 1
 		md := pmetric.NewMetrics()
 		met := md.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
 		met.SetName(exampleDims.name)
@@ -1798,7 +1798,7 @@ func TestMapDoubleMonotonicDropPointPointWithinSlice(t *testing.T) {
 	})
 
 	t.Run("older-rate", func(t *testing.T) {
-		startTs := int(getProcessStartTime()) + 1
+		startTs := getProcessStartTime() + 1
 		md := pmetric.NewMetrics()
 		met := md.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
 		met.SetName(rateAsGaugeDims.name)
@@ -1846,7 +1846,7 @@ func TestMapDoubleMonotonicDropPointPointBeginningOfSlice(t *testing.T) {
 	t.Run("equal", func(t *testing.T) {
 		tr := newTranslator(t, zap.NewNop())
 		dims := &Dimensions{name: exampleDims.name, host: fallbackHostname}
-		startTs := int(getProcessStartTime()) + 1
+		startTs := getProcessStartTime() + 1
 		md := pmetric.NewMetrics()
 		met := md.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
 		met.SetName(dims.name)
@@ -1886,7 +1886,7 @@ func TestMapDoubleMonotonicDropPointPointBeginningOfSlice(t *testing.T) {
 	t.Run("older", func(t *testing.T) {
 		tr := newTranslator(t, zap.NewNop())
 		dims := &Dimensions{name: exampleDims.name, host: fallbackHostname}
-		startTs := int(getProcessStartTime()) + 1
+		startTs := getProcessStartTime() + 1
 		md := pmetric.NewMetrics()
 		met := md.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
 		met.SetName(dims.name)
@@ -1929,7 +1929,7 @@ func TestMapDoubleMonotonicReportFirstValue(t *testing.T) {
 	tr := newTranslator(t, zap.NewNop())
 	consumer := &mockFullConsumer{}
 	tr.MapMetrics(ctx, createTestDoubleCumulativeMonotonicMetrics(false, exampleDims), consumer, nil)
-	startTs := int(getProcessStartTime()) + 1
+	startTs := getProcessStartTime() + 1
 	assert.ElementsMatch(t,
 		consumer.metrics,
 		[]metric{
@@ -1945,7 +1945,7 @@ func TestMapDoubleMonotonicRateDontReportFirstValue(t *testing.T) {
 	tr := newTranslator(t, zap.NewNop())
 	consumer := &mockFullConsumer{}
 	rmt, _ := tr.MapMetrics(ctx, createTestDoubleCumulativeMonotonicMetrics(false, rateAsGaugeDims), consumer, nil)
-	startTs := int(getProcessStartTime()) + 1
+	startTs := getProcessStartTime() + 1
 	assert.ElementsMatch(t,
 		consumer.metrics,
 		[]metric{
@@ -1991,7 +1991,7 @@ func TestMapDoubleMonotonicReportDiffForFirstValue(t *testing.T) {
 	tr := newTranslator(t, zap.NewNop())
 	consumer := &mockFullConsumer{}
 	dims := &Dimensions{name: exampleDims.name, host: fallbackHostname}
-	startTs := int(getProcessStartTime()) + 1
+	startTs := getProcessStartTime() + 1
 	// Add an entry to the cache about the timeseries, in this case we send the diff (9) rather than the first value (10).
 	tr.prevPts.MonotonicDiff(dims, uint64(seconds(startTs)), uint64(seconds(startTs+1)), 1)
 	tr.MapMetrics(ctx, createTestDoubleCumulativeMonotonicMetrics(false, exampleDims), consumer, nil)
@@ -2010,7 +2010,7 @@ func TestMapDoubleMonotonicReportRateForFirstValue(t *testing.T) {
 	tr := newTranslator(t, zap.NewNop())
 	consumer := &mockFullConsumer{}
 	dims := &Dimensions{name: rateAsGaugeDims.name, host: fallbackHostname}
-	startTs := int(getProcessStartTime()) + 1
+	startTs := getProcessStartTime() + 1
 	// Add an entry to the cache about the timeseries, in this case we send the rate (10-1)/(startTs+2-startTs+1) rather than the first value (10).
 	tr.prevPts.MonotonicDiff(dims, uint64(seconds(startTs)), uint64(seconds(startTs+1)), 1)
 	rmt, _ := tr.MapMetrics(ctx, createTestDoubleCumulativeMonotonicMetrics(false, rateAsGaugeDims), consumer, nil)
@@ -2140,7 +2140,7 @@ func createTestIntCumulativeMonotonicMetrics(tsmatch bool, dims *Dimensions) pme
 	dpsInt := met.Sum().DataPoints()
 	dpsInt.EnsureCapacity(len(values))
 
-	startTs := int(getProcessStartTime()) + 1
+	startTs := getProcessStartTime() + 1
 	for i, val := range values {
 		dpInt := dpsInt.AppendEmpty()
 		dpInt.SetStartTimestamp(seconds(startTs))
@@ -2166,7 +2166,7 @@ func createTestDoubleCumulativeMonotonicMetrics(tsmatch bool, dims *Dimensions) 
 	dpsInt := met.Sum().DataPoints()
 	dpsInt.EnsureCapacity(len(values))
 
-	startTs := int(getProcessStartTime()) + 1
+	startTs := getProcessStartTime() + 1
 	for i, val := range values {
 		dpInt := dpsInt.AppendEmpty()
 		dpInt.SetStartTimestamp(seconds(startTs))
@@ -2189,7 +2189,7 @@ func createTestHistogramMetric(metricName string) pmetric.Metrics {
 	met.Histogram().SetAggregationTemporality(pmetric.AggregationTemporalityDelta)
 	hpsCount = met.Histogram().DataPoints()
 	hpsCount.EnsureCapacity(1)
-	startTs := int(getProcessStartTime()) + 1
+	startTs := getProcessStartTime() + 1
 	hpCount := hpsCount.AppendEmpty()
 	hpCount.SetStartTimestamp(seconds(startTs))
 	hpCount.SetTimestamp(seconds(startTs + 1))
@@ -2225,7 +2225,7 @@ func createTestMetricWithAttributes(metricName string, metricType pmetric.Metric
 	if metricType != pmetric.MetricTypeHistogram {
 		dpsInt.EnsureCapacity(dataPoints)
 		for i := 0; i < dataPoints; i++ {
-			startTs := int(getProcessStartTime()) + 1
+			startTs := getProcessStartTime() + 1
 			dpInt := dpsInt.AppendEmpty()
 			for _, attr := range attributes {
 				dpInt.Attributes().PutStr(attr.key, attr.values[i])
@@ -2239,7 +2239,7 @@ func createTestMetricWithAttributes(metricName string, metricType pmetric.Metric
 
 	hpsCount.EnsureCapacity(dataPoints)
 	for i := 0; i < dataPoints; i++ {
-		startTs := int(getProcessStartTime()) + 1
+		startTs := getProcessStartTime() + 1
 		hpCount := hpsCount.AppendEmpty()
 		for _, attr := range attributes {
 			hpCount.Attributes().PutStr(attr.key, attr.values[i])


### PR DESCRIPTION
### Context

Because Datadog does not currently have a concept of cumulative count metrics, we perform cumulative-to-delta conversion in the metrics translator when consuming a monotonic cumulative sum metric. (In the non-monotonic cumulative case, we output a gauge instead). This involves storing the latest value of each metric series, and when receiving a new point, emitting the difference with the previous value.

This however begs the question of how to deal with the first point we receive from a given metric series, since in that scenario we don't have a previous value to compare against. If this is the very first point of the series, then the previous value is implicitly zero, and we can pass through the value as a valid delta. If it isn't, because the translator did not receive previous points from this series, then we can't compute a meaningful delta and must emit nothing.

The heuristic that was chosen to determine this is implemented in the `shouldConsumeInitialValue` function in `pkg/otlp/metrics/metrics_translator.go`: in the default "auto" mode, we emit the initial point as a delta if the start timestamp of the metric series is set, and comes _after_ the start of the metrics translator code.

(This assumes the main reason the translator may not receive points from a series is that it hadn't started yet. We also have options to always emit, or always drop the initial point to hopefully cover other cases.)

### What does this PR do?

This PR fixes the timestamp comparison in `shouldConsumeInitialValue`. Previously, `startTs` was compared to `getProcessStartTime()`, even though the former is in nanoseconds and the latter in seconds. This meant that in the most common scenario, we always treated the first received point as a valid delta, resulting in large "spikes" when the Agent/Collector containing the translator restarted but the application did not.

This PR also adds a new test which checks the correct behavior of `mapNumberMonotonicMetrics` for all three values of `InitialCumulMonoValueMode`, and in the cases of both an "app restart" (ie. the metric series started after the translator did), and an "agent restart" (ie. the metric series started before the translator did).

