### PR TITLE
Add support for host aliases

### DIFF
--- a/.chloggen/mackjmr_support-host-aliases.yaml
+++ b/.chloggen/mackjmr_support-host-aliases.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: enhancement
+
+# The name of the component (e.g. pkg/quantile)
+component: pkg/inframetadata
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add support for host aliasing via resource attribute datadog.host.aliases
+
+# The PR related to this change
+issues: [661]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/pkg/inframetadata/internal/hostmap/hostmap.go
+++ b/pkg/inframetadata/internal/hostmap/hostmap.go
@@ -221,6 +221,15 @@ func (m *HostMap) Update(host string, res pcommon.Resource) (changed bool, md pa
 		md.Tags.OTel = tags
 	}
 
+	// Host Aliases
+	hostAliases := getHostAliases(res.Attributes())
+	old := md.Meta.HostAliases
+	changed = changed || !equalSlices[[]string](old, hostAliases)
+	md.Meta.HostAliases = hostAliases
+
+	// If a tag was present in a previous resource but is not present
+	// in the current one, it will be removed from the host metadata payload.
+
 	// InstanceID field
 	if iid, ok, err2 := instanceID(res.Attributes()); err2 != nil {
 		err = errors.Join(err, err2)
@@ -303,7 +312,7 @@ func (m *HostMap) Update(host string, res pcommon.Resource) (changed bool, md pa
 	}
 
 	m.hosts[host] = md
-	changed = changed && !found
+	changed = changed || !found
 	return
 }
 

--- a/pkg/inframetadata/internal/hostmap/hostmap_test.go
+++ b/pkg/inframetadata/internal/hostmap/hostmap_test.go
@@ -253,7 +253,6 @@ func TestUpdate(t *testing.T) {
 				conventions.AttributeHostArch:      conventions.AttributeHostArchARM64,
 				"deployment.environment.name":      "staging",
 				"datadog.host.aliases":             []any{"host-2-hostid-alias-1", "host-2-hostid-alias-2", "host-2-hostid-alias-3"},
-
 			},
 			expectedChanged: true,
 		},

--- a/pkg/inframetadata/internal/hostmap/hostmap_test.go
+++ b/pkg/inframetadata/internal/hostmap/hostmap_test.go
@@ -205,7 +205,7 @@ func TestUpdate(t *testing.T) {
 				"datadog.host.tag.foo":                     "baz",                                                 // changed
 				conventions.AttributeDeploymentEnvironment: "prod",
 			},
-			expectedChanged: false,
+			expectedChanged: true,
 			expectedErrs:    []string{"\"os.description\" has type \"Bool\", expected type \"Str\" instead"},
 		},
 		{
@@ -239,6 +239,21 @@ func TestUpdate(t *testing.T) {
 				conventions.AttributeHostName:      "host-2-hostname",
 				conventions.AttributeHostArch:      conventions.AttributeHostArchARM64,
 				"deployment.environment.name":      "staging",
+				"datadog.host.aliases":             []any{"host-2-hostid-alias-1", "host-2-hostid-alias-2"},
+			},
+			expectedChanged: true,
+		},
+		{
+			// Same host, new aliases
+			hostname: "host-2-hostid",
+			attributes: map[string]any{
+				conventions.AttributeCloudProvider: conventions.AttributeCloudProviderAzure,
+				conventions.AttributeHostID:        "host-2-hostid",
+				conventions.AttributeHostName:      "host-2-hostname",
+				conventions.AttributeHostArch:      conventions.AttributeHostArchARM64,
+				"deployment.environment.name":      "staging",
+				"datadog.host.aliases":             []any{"host-2-hostid-alias-1", "host-2-hostid-alias-2", "host-2-hostid-alias-3"},
+
 			},
 			expectedChanged: true,
 		},
@@ -308,7 +323,8 @@ func TestUpdate(t *testing.T) {
 		assert.Equal(t, md.InternalHostname, "host-2-hostid")
 		assert.Equal(t, md.Flavor, "otelcol-contrib")
 		assert.Equal(t, md.Meta, &payload.Meta{
-			Hostname: "host-2-hostid",
+			Hostname:    "host-2-hostid",
+			HostAliases: []string{"host-2-hostid-alias-1", "host-2-hostid-alias-2", "host-2-hostid-alias-3"},
 		})
 		assert.ElementsMatch(t, md.Tags.OTel, []string{"cloud_provider:azure", "env:staging"})
 		assert.Equal(t, md.Platform(), map[string]string{

--- a/pkg/inframetadata/internal/hostmap/tags.go
+++ b/pkg/inframetadata/internal/hostmap/tags.go
@@ -69,7 +69,7 @@ func getHostTags(m pcommon.Map) ([]string, error) {
 
 // getHostAliases tries to get a host aliases from attribute datadog.host.aliases
 func getHostAliases(attrs pcommon.Map) []string {
-	hostAliases := []string{}
+	var hostAliases []string
 	attrs.Range(func(k string, v pcommon.Value) bool {
 		if k == hostAliasAttribute {
 			if v.Type() != pcommon.ValueTypeSlice {

--- a/pkg/inframetadata/internal/hostmap/tags.go
+++ b/pkg/inframetadata/internal/hostmap/tags.go
@@ -69,9 +69,12 @@ func getHostTags(m pcommon.Map) ([]string, error) {
 
 // getHostAliases tries to get a host aliases from attribute datadog.host.aliases
 func getHostAliases(attrs pcommon.Map) []string {
-	var hostAliases []string
+	hostAliases := []string{}
 	attrs.Range(func(k string, v pcommon.Value) bool {
 		if k == hostAliasAttribute {
+			if v.Type() != pcommon.ValueTypeSlice {
+				return false
+			}
 			hostAliasesAny := v.Slice().AsRaw()
 			for _, hostAlias := range hostAliasesAny {
 				if hostAliasStr, ok := hostAlias.(string); ok {

--- a/pkg/inframetadata/internal/hostmap/tags_test.go
+++ b/pkg/inframetadata/internal/hostmap/tags_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestGetHostAliases(t *testing.T) {
+	var uninitializedSlice []string
 	tests := []struct {
 		name     string
 		attrs    func() pcommon.Map
@@ -23,7 +24,7 @@ func TestGetHostAliases(t *testing.T) {
 			attrs: func() pcommon.Map {
 				return pcommon.NewMap()
 			},
-			expected: []string{},
+			expected: uninitializedSlice,
 		},
 		{
 			name: "attribute not present",
@@ -32,7 +33,7 @@ func TestGetHostAliases(t *testing.T) {
 				m.PutStr("some.other.key", "value")
 				return m
 			},
-			expected: []string{},
+			expected: uninitializedSlice,
 		},
 		{
 			name: "host aliases present",
@@ -64,7 +65,7 @@ func TestGetHostAliases(t *testing.T) {
 				m.PutStr(hostAliasAttribute, "alias")
 				return m
 			},
-			expected: []string{},
+			expected: uninitializedSlice,
 		},
 		{
 			name: "empty slice",
@@ -73,7 +74,7 @@ func TestGetHostAliases(t *testing.T) {
 				m.PutEmptySlice(hostAliasAttribute)
 				return m
 			},
-			expected: []string{},
+			expected: uninitializedSlice,
 		},
 		{
 			name: "non initialized slice",
@@ -83,7 +84,7 @@ func TestGetHostAliases(t *testing.T) {
 				m.FromRaw(map[string]any{hostAliasAttribute: nonInitializedSlice})
 				return m
 			},
-			expected: []string{},
+			expected: uninitializedSlice,
 		},
 	}
 

--- a/pkg/inframetadata/internal/hostmap/tags_test.go
+++ b/pkg/inframetadata/internal/hostmap/tags_test.go
@@ -1,0 +1,96 @@
+// Unless explicitly stated otherwise all files in this repository are licensed
+// under the Apache License Version 2.0.
+// This product includes software developed at Datadog (https://www.datadoghq.com/).
+// Copyright 2023-present Datadog, Inc.
+
+package hostmap
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+)
+
+func TestGetHostAliases(t *testing.T) {
+	tests := []struct {
+		name     string
+		attrs    func() pcommon.Map
+		expected []string
+	}{
+		{
+			name: "no attributes",
+			attrs: func() pcommon.Map {
+				return pcommon.NewMap()
+			},
+			expected: []string{},
+		},
+		{
+			name: "attribute not present",
+			attrs: func() pcommon.Map {
+				m := pcommon.NewMap()
+				m.PutStr("some.other.key", "value")
+				return m
+			},
+			expected: []string{},
+		},
+		{
+			name: "host aliases present",
+			attrs: func() pcommon.Map {
+				m := pcommon.NewMap()
+				slice := m.PutEmptySlice(hostAliasAttribute)
+				slice.AppendEmpty().SetStr("alias1")
+				slice.AppendEmpty().SetStr("alias2")
+				return m
+			},
+			expected: []string{"alias1", "alias2"},
+		},
+		{
+			name: "host aliases present but with mixed types",
+			attrs: func() pcommon.Map {
+				m := pcommon.NewMap()
+				slice := m.PutEmptySlice(hostAliasAttribute)
+				slice.AppendEmpty().SetStr("alias1")
+				slice.AppendEmpty().SetInt(123) // invalid, will be skipped
+				slice.AppendEmpty().SetStr("alias2")
+				return m
+			},
+			expected: []string{"alias1", "alias2"},
+		},
+		{
+			name: "wrong type, no panic",
+			attrs: func() pcommon.Map {
+				m := pcommon.NewMap()
+				m.PutStr(hostAliasAttribute, "alias")
+				return m
+			},
+			expected: []string{},
+		},
+		{
+			name: "empty slice",
+			attrs: func() pcommon.Map {
+				m := pcommon.NewMap()
+				m.PutEmptySlice(hostAliasAttribute)
+				return m
+			},
+			expected: []string{},
+		},
+		{
+			name: "non initialized slice",
+			attrs: func() pcommon.Map {
+				var nonInitializedSlice []string
+				m := pcommon.NewMap()
+				m.FromRaw(map[string]any{hostAliasAttribute: nonInitializedSlice})
+				return m
+			},
+			expected: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := getHostAliases(tt.attrs())
+			assert.Equal(t, tt.expected, result)
+		})
+	}
+}


### PR DESCRIPTION
### What does this PR do?

This PR adds support for host aliases. Users can now set host aliases by setting resource attribute `datadog.host.use_as_metadata` to true and `datadog.host.aliases` as a slice of host aliases.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

