### PR TITLE
Reduce iteration count in TestSummary/InsertN to avoid flakes

### DIFF
--- a/pkg/quantile/summary/summary_test.go
+++ b/pkg/quantile/summary/summary_test.go
@@ -60,7 +60,7 @@ func TestSummary(t *testing.T) {
 			s, exp = Summary{}, Summary{}
 		)
 
-		for i := 0; i < 1000; i++ {
+		for i := 0; i < 20; i++ {
 			v := math.Floor(rand.Float64() * 10000)
 			nInsert := rand.Intn(1000) + 1
 


### PR DESCRIPTION
### What does this PR do?

This PR decreases the number of iterations of the `TestSummary/InsertN` test in `pkg/quantile/summary/summary_test.go` from 1000 to 20.

### Motivation

This test compares the result of calling `Summary.Insert` multiple times versus calling `Summary.InsertN` once. Even if the logic is mathematically correct, due to floating-point imprecision, this can give slightly different results for the sum, and especially for the average, because of the formula that's currently used. And as we repeat the test multiple times, these errors can accumulate past the comparison threshold (256 ULPs).

The current iteration count (1000) causes the test to flake a few percent of the time ([recent example on main CI](https://github.com/DataDog/opentelemetry-mapping-go/actions/runs/15588651484/job/43901727793)), depending on the random input values generated.

Using a greedy search, I've found that it's possible to exceed the comparison threshold for the average in as few as 32 iterations, if the random values are just right. This is my basis for choosing the new iteration count of 20, which should hopefully never flake with our current comparison threshold, while still allowing us to detect regressions if we somehow break the `Summary.InsertN` algorithm significantly.
