### PR TITLE
[pkg/otlp/metrics] Do not consume host if you only see APM metrics

### DIFF
--- a/.chloggen/mx-psi_do-not-record-host-for-stats-metrics.yaml
+++ b/.chloggen/mx-psi_do-not-record-host-for-stats-metrics.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component (e.g. pkg/quantile)
+component: pkg/otlp/metrics
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: "Do not consume host or tags for ResourceMetrics that only contain APM metrics."
+
+# The PR related to this change
+issues: [721]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/pkg/otlp/metrics/metrics_translator.go
+++ b/pkg/otlp/metrics/metrics_translator.go
@@ -753,17 +753,14 @@ func (t *Translator) MapMetrics(ctx context.Context, md pmetric.Metrics, consume
 		}
 
 		var host string
-		switch src.Kind {
-		case source.HostnameKind:
+		if src.Kind == source.HostnameKind {
 			host = src.Identifier
-			if c, ok := consumer.(HostConsumer); ok {
-				c.ConsumeHost(host)
-			}
-		case source.AWSECSFargateKind:
-			if c, ok := consumer.(TagsConsumer); ok {
-				c.ConsumeTag(src.Tag())
-			}
+			// Don't consume the host yet, first check if we have any nonAPM metrics.
 		}
+
+		// seenNonAPMMetrics is used to determine if we have seen any non-APM metrics in this ResourceMetrics.
+		// If we have only seen APM metrics, we don't want to consume the host.
+		var seenNonAPMMetrics bool
 
 		// Fetch tags from attributes.
 		attributeTags := attributes.TagsFromAttributes(rm.Resource().Attributes())
@@ -815,6 +812,10 @@ func (t *Translator) MapMetrics(ctx context.Context, md pmetric.Metrics, consume
 							mapHistogramRuntimeMetricWithAttributes(md, newMetrics, mp)
 						}
 					}
+				} else {
+					// If we are here, we have a non-APM metric:
+					// it is not a stats metric, nor a runtime metric.
+					seenNonAPMMetrics = true
 				}
 
 				if t.cfg.withRemapping {
@@ -830,6 +831,20 @@ func (t *Translator) MapMetrics(ctx context.Context, md pmetric.Metrics, consume
 			for k := 0; k < newMetrics.Len(); k++ {
 				md := newMetrics.At(k)
 				t.mapToDDFormat(ctx, md, consumer, additionalTags, host, scopeName, rattrs)
+			}
+		}
+
+		// Only consume the source if we have seen non-APM metrics.
+		if seenNonAPMMetrics {
+			switch src.Kind {
+			case source.HostnameKind:
+				if c, ok := consumer.(HostConsumer); ok {
+					c.ConsumeHost(host)
+				}
+			case source.AWSECSFargateKind:
+				if c, ok := consumer.(TagsConsumer); ok {
+					c.ConsumeTag(src.Tag())
+				}
 			}
 		}
 	}


### PR DESCRIPTION
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Avoids calling `ConsumeHost`/`ConsumeTag` if you only have APM metrics.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

While these are metrics they are considered part of the APM product