### PR TITLE
[breaking][pkg/otlp/metrics] Pass interval as part of ConsumeTimeSeries and ConsumeSketch function

### DIFF
--- a/.chloggen/mx-psi_delta-interval-infer.yaml
+++ b/.chloggen/mx-psi_delta-interval-infer.yaml
@@ -1,0 +1,17 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: breaking
+
+# The name of the component (e.g. pkg/quantile)
+component: pkg/otlp/metrics
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Add interval argument to Consumer methods. 
+
+# The PR related to this change
+issues: [725]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext: |
+  All intervals passed as of this change will be 0, which is equivalent to the previous behavior.

--- a/pkg/otlp/metrics/consumer.go
+++ b/pkg/otlp/metrics/consumer.go
@@ -69,6 +69,7 @@ type TimeSeriesConsumer interface {
 		dimensions *Dimensions,
 		typ DataType,
 		timestamp uint64,
+		interval int64,
 		value float64,
 	)
 }

--- a/pkg/otlp/metrics/consumer.go
+++ b/pkg/otlp/metrics/consumer.go
@@ -81,6 +81,7 @@ type SketchConsumer interface {
 		ctx context.Context,
 		dimensions *Dimensions,
 		timestamp uint64,
+		interval int64,
 		sketch *quantile.Sketch,
 	)
 }

--- a/pkg/otlp/metrics/exponential_histograms_translator.go
+++ b/pkg/otlp/metrics/exponential_histograms_translator.go
@@ -121,17 +121,17 @@ func (t *Translator) mapExponentialHistogramMetrics(
 
 		if t.cfg.SendHistogramAggregations && histInfo.ok {
 			// We only send the sum and count if both values were ok.
-			consumer.ConsumeTimeSeries(ctx, countDims, Count, ts, float64(histInfo.count))
-			consumer.ConsumeTimeSeries(ctx, sumDims, Count, ts, histInfo.sum)
+			consumer.ConsumeTimeSeries(ctx, countDims, Count, ts, 0, float64(histInfo.count))
+			consumer.ConsumeTimeSeries(ctx, sumDims, Count, ts, 0, histInfo.sum)
 
 			if delta {
 				if p.HasMin() {
 					minDims := pointDims.WithSuffix("min")
-					consumer.ConsumeTimeSeries(ctx, minDims, Gauge, ts, p.Min())
+					consumer.ConsumeTimeSeries(ctx, minDims, Gauge, ts, 0, p.Min())
 				}
 				if p.HasMax() {
 					maxDims := pointDims.WithSuffix("max")
-					consumer.ConsumeTimeSeries(ctx, maxDims, Gauge, ts, p.Max())
+					consumer.ConsumeTimeSeries(ctx, maxDims, Gauge, ts, 0, p.Max())
 				}
 			}
 		}

--- a/pkg/otlp/metrics/exponential_histograms_translator.go
+++ b/pkg/otlp/metrics/exponential_histograms_translator.go
@@ -174,6 +174,6 @@ func (t *Translator) mapExponentialHistogramMetrics(
 			agentSketch.Basic.Max = p.Max()
 		}
 
-		consumer.ConsumeSketch(ctx, pointDims, ts, agentSketch)
+		consumer.ConsumeSketch(ctx, pointDims, ts, 0, agentSketch)
 	}
 }

--- a/pkg/otlp/metrics/metrics_translator.go
+++ b/pkg/otlp/metrics/metrics_translator.go
@@ -169,7 +169,7 @@ func (t *Translator) mapNumberMetrics(
 			continue
 		}
 
-		consumer.ConsumeTimeSeries(ctx, pointDims, dt, uint64(p.Timestamp()), val)
+		consumer.ConsumeTimeSeries(ctx, pointDims, dt, uint64(p.Timestamp()), 0, val)
 	}
 }
 
@@ -239,7 +239,7 @@ func (t *Translator) mapNumberMonotonicMetrics(
 			if shouldDropPoint {
 				t.logger.Debug("Dropping point: timestamp is older or equal to timestamp of previous point received", zap.String(metricName, pointDims.name))
 			} else if !isFirstPoint {
-				consumer.ConsumeTimeSeries(ctx, pointDims, Gauge, ts, dx)
+				consumer.ConsumeTimeSeries(ctx, pointDims, Gauge, ts, 0, dx)
 			}
 			continue
 		}
@@ -251,11 +251,11 @@ func (t *Translator) mapNumberMonotonicMetrics(
 		}
 
 		if !isFirstPoint {
-			consumer.ConsumeTimeSeries(ctx, pointDims, Count, ts, dx)
+			consumer.ConsumeTimeSeries(ctx, pointDims, Count, ts, 0, dx)
 		} else if i == 0 && t.shouldConsumeInitialValue(startTs, ts) {
 			// We only compute the first point in the timeseries if it is the first value in the datapoint slice.
 			// Todo: Investigate why we don't compute first val if i > 0 and add reason as comment.
-			consumer.ConsumeTimeSeries(ctx, pointDims, Count, ts, val)
+			consumer.ConsumeTimeSeries(ctx, pointDims, Count, ts, 0, val)
 		}
 	}
 }
@@ -436,9 +436,9 @@ func (t *Translator) getLegacyBuckets(
 
 		count := float64(p.BucketCounts().At(idx))
 		if delta {
-			consumer.ConsumeTimeSeries(ctx, bucketDims, Count, ts, count)
+			consumer.ConsumeTimeSeries(ctx, bucketDims, Count, ts, 0, count)
 		} else if dx, ok := t.prevPts.Diff(bucketDims, startTs, ts, count); ok {
-			consumer.ConsumeTimeSeries(ctx, bucketDims, Count, ts, dx)
+			consumer.ConsumeTimeSeries(ctx, bucketDims, Count, ts, 0, dx)
 		}
 	}
 }
@@ -510,8 +510,8 @@ func (t *Translator) mapHistogramMetrics(
 
 		if t.cfg.SendHistogramAggregations && histInfo.ok {
 			// We only send the sum and count if both values were ok.
-			consumer.ConsumeTimeSeries(ctx, countDims, Count, ts, float64(histInfo.count))
-			consumer.ConsumeTimeSeries(ctx, sumDims, Count, ts, histInfo.sum)
+			consumer.ConsumeTimeSeries(ctx, countDims, Count, ts, 0, float64(histInfo.count))
+			consumer.ConsumeTimeSeries(ctx, sumDims, Count, ts, 0, histInfo.sum)
 
 			if delta {
 				// We could check is[Min/Max]FromLastTimeWindow here, and report the minimum/maximum
@@ -520,10 +520,10 @@ func (t *Translator) mapHistogramMetrics(
 				// where the min/max is (pressumably) available in either all or none of the points.
 
 				if p.HasMin() {
-					consumer.ConsumeTimeSeries(ctx, minDims, Gauge, ts, p.Min())
+					consumer.ConsumeTimeSeries(ctx, minDims, Gauge, ts, 0, p.Min())
 				}
 				if p.HasMax() {
-					consumer.ConsumeTimeSeries(ctx, maxDims, Gauge, ts, p.Max())
+					consumer.ConsumeTimeSeries(ctx, maxDims, Gauge, ts, 0, p.Max())
 				}
 			}
 		}
@@ -592,10 +592,10 @@ func (t *Translator) mapSummaryMetrics(
 			dx, isFirstPoint, shouldDropPoint := t.prevPts.MonotonicDiff(countDims, startTs, ts, val)
 			if !shouldDropPoint && !t.isSkippable(countDims.name, dx) {
 				if !isFirstPoint {
-					consumer.ConsumeTimeSeries(ctx, countDims, Count, ts, dx)
+					consumer.ConsumeTimeSeries(ctx, countDims, Count, ts, 0, dx)
 				} else if i == 0 && t.shouldConsumeInitialValue(startTs, ts) {
 					// We only compute the first point in the timeseries if it is the first value in the datapoint slice.
-					consumer.ConsumeTimeSeries(ctx, countDims, Count, ts, val)
+					consumer.ConsumeTimeSeries(ctx, countDims, Count, ts, 0, val)
 				}
 			}
 		}
@@ -604,7 +604,7 @@ func (t *Translator) mapSummaryMetrics(
 			sumDims := pointDims.WithSuffix("sum")
 			if !t.isSkippable(sumDims.name, p.Sum()) {
 				if dx, ok := t.prevPts.Diff(sumDims, startTs, ts, p.Sum()); ok {
-					consumer.ConsumeTimeSeries(ctx, sumDims, Count, ts, dx)
+					consumer.ConsumeTimeSeries(ctx, sumDims, Count, ts, 0, dx)
 				}
 			}
 		}
@@ -620,7 +620,7 @@ func (t *Translator) mapSummaryMetrics(
 				}
 
 				quantileDims := baseQuantileDims.AddTags(getQuantileTag(q.Quantile()))
-				consumer.ConsumeTimeSeries(ctx, quantileDims, Gauge, ts, q.Value())
+				consumer.ConsumeTimeSeries(ctx, quantileDims, Gauge, ts, 0, q.Value())
 			}
 		}
 	}

--- a/pkg/otlp/metrics/metrics_translator.go
+++ b/pkg/otlp/metrics/metrics_translator.go
@@ -411,7 +411,7 @@ func (t *Translator) getSketchBuckets(
 			sketch.Basic.Max = math.Min(p.Max(), sketch.Basic.Max)
 		}
 
-		consumer.ConsumeSketch(ctx, pointDims, ts, sketch)
+		consumer.ConsumeSketch(ctx, pointDims, ts, 0, sketch)
 	}
 }
 

--- a/pkg/otlp/metrics/metrics_translator_test.go
+++ b/pkg/otlp/metrics/metrics_translator_test.go
@@ -141,6 +141,7 @@ type sketch struct {
 	name      string
 	basic     summary.Summary
 	timestamp uint64
+	interval  int64
 	tags      []string
 	host      string
 }
@@ -2061,12 +2062,13 @@ type mockFullConsumer struct {
 	sketches []sketch
 }
 
-func (c *mockFullConsumer) ConsumeSketch(_ context.Context, dimensions *Dimensions, ts uint64, sk *quantile.Sketch) {
+func (c *mockFullConsumer) ConsumeSketch(_ context.Context, dimensions *Dimensions, ts uint64, interval int64, sk *quantile.Sketch) {
 	c.sketches = append(c.sketches,
 		sketch{
 			name:      dimensions.Name(),
 			basic:     sk.Basic,
 			timestamp: ts,
+			interval:  interval,
 			tags:      dimensions.Tags(),
 			host:      dimensions.Host(),
 		},

--- a/pkg/otlp/metrics/metrics_translator_test.go
+++ b/pkg/otlp/metrics/metrics_translator_test.go
@@ -131,6 +131,7 @@ type metric struct {
 	name      string
 	typ       DataType
 	timestamp uint64
+	interval  int64
 	value     float64
 	tags      []string
 	host      string
@@ -155,6 +156,7 @@ func (m *mockTimeSeriesConsumer) ConsumeTimeSeries(
 	dimensions *Dimensions,
 	typ DataType,
 	ts uint64,
+	interval int64,
 	val float64,
 ) {
 	m.metrics = append(m.metrics,
@@ -162,6 +164,7 @@ func (m *mockTimeSeriesConsumer) ConsumeTimeSeries(
 			name:      dimensions.Name(),
 			typ:       typ,
 			timestamp: ts,
+			interval:  interval,
 			value:     val,
 			tags:      dimensions.Tags(),
 			host:      dimensions.Host(),

--- a/pkg/otlp/metrics/sketches_test.go
+++ b/pkg/otlp/metrics/sketches_test.go
@@ -44,6 +44,7 @@ func (c *sketchConsumer) ConsumeSketch(
 	_ context.Context,
 	_ *Dimensions,
 	_ uint64,
+	_ int64,
 	sketch *quantile.Sketch,
 ) {
 	c.sk = sketch

--- a/pkg/otlp/metrics/testhelper_test.go
+++ b/pkg/otlp/metrics/testhelper_test.go
@@ -178,6 +178,7 @@ func (t *testConsumer) ConsumeSketch(
 	_ context.Context,
 	dimensions *Dimensions,
 	timestamp uint64,
+	interval int64,
 	sketch *quantile.Sketch,
 ) {
 	k, n := sketch.Cols()

--- a/pkg/otlp/metrics/testhelper_test.go
+++ b/pkg/otlp/metrics/testhelper_test.go
@@ -71,6 +71,7 @@ type TestSketch struct {
 type TestTimeSeries struct {
 	TestDimensions
 	Type      DataType
+	Interval  int64
 	Timestamp uint64
 	Value     float64
 }
@@ -153,6 +154,7 @@ func (t *testConsumer) ConsumeTimeSeries(
 	dimensions *Dimensions,
 	typ DataType,
 	timestamp uint64,
+	interval int64,
 	value float64,
 ) {
 	t.data.Metrics.TimeSeries = append(t.data.Metrics.TimeSeries,


### PR DESCRIPTION
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Explicitly pass `interval` when consuming sketches and timeseries.

The interval type varies between implementations:
- [Zorkian uses `int`](https://pkg.go.dev/gopkg.in/zorkian/go-datadog-api.v2#Metric)
- [datadog-api-client uses `*int64`](https://pkg.go.dev/github.com/DataDog/datadog-api-client-go/v2@v2.19.0/api/datadogV2#MetricSeries)
- [serializer implementation uses `int64`](https://github.com/DataDog/datadog-agent/blob/66a632665c776c6f92397eb4e88f74dc88e143ba/pkg/metrics/series.go#L56)

I have decided to favor the serializer one (`int64`). [`0` is the same as unset](https://github.com/DataDog/datadog-agent/blob/66a632665c776c6f92397eb4e88f74dc88e143ba/comp/otelcol/otlp/components/exporter/serializerexporter/consumer.go#L146).

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

This allows us to pass interval data if we ever want to infer it or add it via attributes
