### PR TITLE
Add support for log attr value int/double/bool types

### DIFF
--- a/.chloggen/mackjmr_support-different-log-attr-types.yaml
+++ b/.chloggen/mackjmr_support-different-log-attr-types.yaml
@@ -1,0 +1,16 @@
+# One of 'breaking', 'deprecation', 'new_component', 'enhancement', 'bug_fix'
+change_type: bug_fix
+
+# The name of the component (e.g. pkg/quantile)
+component: pkg/otlp/logs
+
+# A brief description of the change. Surround your text with quotes ("") if it needs to start with a backtick (`).
+note: Log attribute values of type bool, int and double will be represented as such. Previously, they were incorrectly converted to string.
+
+# The PR related to this change
+issues: [740]
+
+# (Optional) One or more lines of additional information to render under the primary note.
+# These lines will be padded with 2 spaces and then inserted directly into the document.
+# Use pipe (|) for multiline entries.
+subtext:

--- a/pkg/otlp/logs/transform.go
+++ b/pkg/otlp/logs/transform.go
@@ -182,11 +182,18 @@ func transform(lr plog.LogRecord, host, service string, res pcommon.Resource, sc
 	return l
 }
 
-func flattenAttribute(key string, val pcommon.Value, depth int) map[string]string {
-	result := make(map[string]string)
+func flattenAttribute(key string, val pcommon.Value, depth int) map[string]any {
+	result := make(map[string]any)
 
 	if val.Type() != pcommon.ValueTypeMap || depth == 10 {
-		result[key] = val.AsString()
+		if val.Type() == pcommon.ValueTypeStr ||
+			val.Type() == pcommon.ValueTypeInt ||
+			val.Type() == pcommon.ValueTypeBool ||
+			val.Type() == pcommon.ValueTypeDouble {
+			result[key] = val.AsRaw()
+		} else {
+			result[key] = val.AsString()
+		}
 		return result
 	}
 

--- a/pkg/otlp/logs/transform_test.go
+++ b/pkg/otlp/logs/transform_test.go
@@ -72,6 +72,36 @@ func TestTranslator(t *testing.T) {
 			},
 		},
 		{
+			// different attribute types
+			name: "basic",
+			args: args{
+				lr: func() plog.LogRecord {
+					l := plog.NewLogRecord()
+					l.Attributes().PutStr("app", "test")
+					l.Attributes().PutBool("test_bool", true)
+					l.Attributes().PutInt("test_int", 1234)
+					l.Attributes().PutDouble("test_double", 1.234)
+					l.SetSeverityNumber(5)
+					return l
+				}(),
+				res:   pcommon.NewResource(),
+				scope: pcommon.NewInstrumentationScope(),
+			},
+			want: datadogV2.HTTPLogItem{
+				Ddtags:  datadog.PtrString("otel_source:test"),
+				Message: *datadog.PtrString(""),
+				AdditionalProperties: map[string]interface{}{
+					"app":              "test",
+					"status":           "debug",
+					"test_bool":        true,
+					"test_int":         1234,
+					"test_double":      1.234,
+					otelSeverityNumber: "5",
+				},
+			},
+		},
+
+		{
 			// log & resource with attribute
 			name: "resource",
 			args: args{


### PR DESCRIPTION
### What does this PR do?

This PR adds support for multiple log attributes value types: `string`, `integer`, `double`, `boolean` (Types were taken from: [Attributes and Aliasing](https://docs.datadoghq.com/logs/log_configuration/attributes_naming_convention/#create-a-new-standard-attribute) )

### Motivation

OTAGENT-432
