### PR TITLE
feat(otel-2740): deconstruct ddforward into resource

### DIFF
--- a/pkg/otlp/rum/rum_logs.go
+++ b/pkg/otlp/rum/rum_logs.go
@@ -11,7 +11,8 @@ func ToLogs(payload map[string]any, req *http.Request) plog.Logs {
 	results := plog.NewLogs()
 	rl := results.ResourceLogs().AppendEmpty()
 	rl.SetSchemaUrl(semconv.SchemaURL)
-	parseRUMRequestIntoResource(rl.Resource(), req.URL.Query().Get("ddforward"))
+	rl.Resource().Attributes().PutStr(semconv.AttributeServiceName, "browser-rum-sdk")
+	parseDDForwardIntoResource(rl.Resource().Attributes(), req.URL.Query().Get("ddforward"))
 
 	in := rl.ScopeLogs().AppendEmpty()
 	in.Scope().SetName(InstrumentationScopeName)

--- a/pkg/otlp/rum/rum_test.go
+++ b/pkg/otlp/rum/rum_test.go
@@ -265,3 +265,56 @@ func TestConstructRumPayloadFromOTLP(t *testing.T) {
 		})
 	}
 }
+
+func TestParseDDForwardIntoResource(t *testing.T) {
+	tests := []struct {
+		name      string
+		ddforward string
+		expected  pcommon.Map
+	}{
+		{
+			name:      "empty ddforward",
+			ddforward: "",
+			expected:  pcommon.NewMap(),
+		},
+		{
+			name:      "successful parse of ddforward",
+			ddforward: "/api/v2/rum?ddsource=browser&ddtags=sdk_version:4.41.0,env:prod,service:test-app,version:2.0.0-beta&dd-evp-origin=browser&dd-request-id=1234-5678-91a-bcde&batch_time=1682595634052",
+			expected: func() pcommon.Map {
+				m := pcommon.NewMap()
+				m.PutStr("batch_time", "1682595634052")
+				m.PutStr("ddsource", "browser")
+
+				ddtags := m.PutEmptyMap("ddtags")
+				ddtags.PutStr("sdk_version", "4.41.0")
+				ddtags.PutStr("env", "prod")
+				ddtags.PutStr("service", "test-app")
+				ddtags.PutStr("version", "2.0.0-beta")
+
+				m.PutStr("dd-evp-origin", "browser")
+				m.PutStr("dd-request-id", "1234-5678-91a-bcde")
+				return m
+			}(),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			attributes := pcommon.NewMap()
+			parseDDForwardIntoResource(attributes, tt.ddforward)
+			tt.expected.Range(func(key string, expectedValue pcommon.Value) bool {
+				actualValue, _ := attributes.Get(key)
+				if key == "ddtags" {
+					expectedValue.Map().Range(func(mapKey string, mapValue pcommon.Value) bool {
+						actualDDTagsValue, _ := actualValue.Map().Get(mapKey)
+						assert.Equal(t, mapValue.AsString(), actualDDTagsValue.AsString())
+						return true
+					})
+				} else {
+					assert.Equal(t, expectedValue.AsString(), actualValue.AsString())
+				}
+				return true
+			})
+		})
+	}
+}

--- a/pkg/otlp/rum/rum_traces.go
+++ b/pkg/otlp/rum/rum_traces.go
@@ -14,7 +14,8 @@ func ToTraces(logger *zap.Logger, payload map[string]any, req *http.Request) (pt
 	results := ptrace.NewTraces()
 	rs := results.ResourceSpans().AppendEmpty()
 	rs.SetSchemaUrl(semconv.SchemaURL)
-	parseRUMRequestIntoResource(rs.Resource(), req.URL.Query().Get("ddforward"))
+	rs.Resource().Attributes().PutStr(semconv.AttributeServiceName, "browser-rum-sdk")
+	parseDDForwardIntoResource(rs.Resource().Attributes(), req.URL.Query().Get("ddforward"))
 
 	in := rs.ScopeSpans().AppendEmpty()
 	in.Scope().SetName(InstrumentationScopeName)


### PR DESCRIPTION
### What does this PR do?
As part of the effort to construct ddforward url in the exporter, we need to pass the ddforward url's query parameters as attributes in the RUM resource. The steps to construction are:
1. Deconstruct ddforward params into attributes in the receiver
2) In the exporter, construct ddforward; take whatever we can from OTel semantic conventions (e.g. `service`, `batch_time` (which might be able to use `date`), and `ddsource` /`dd-evp-origin` which can be taken from `source`); whatever is not available from semantic conventions, take from the deconstructed ddforward params and then have a fallback

### Motivation
The motivation for constructing the ddforward url in the exporter vs grabbing the entire ddforward url from the request and then setting that as a resource attribute is that when we're taking RUM from OTel browser SDKs, where there's no ddforward, our exporter logic should still work. 
https://datadoghq.atlassian.net/browse/OTEL-2740
