### PR TITLE
[OTEL-2697][pkg/otlp/metrics] Add WithInferDeltaInterval option

### DIFF
--- a/pkg/otlp/metrics/config.go
+++ b/pkg/otlp/metrics/config.go
@@ -29,6 +29,7 @@ type translatorConfig struct {
 	InitialCumulMonoValueMode            InitialCumulMonoValueMode
 	InstrumentationLibraryMetadataAsTags bool
 	InstrumentationScopeMetadataAsTags   bool
+	InferDeltaInterval                   bool
 
 	originProduct OriginProduct
 
@@ -229,6 +230,15 @@ const (
 func WithInitialCumulMonoValueMode(mode InitialCumulMonoValueMode) TranslatorOption {
 	return func(t *translatorConfig) error {
 		t.InitialCumulMonoValueMode = mode
+		return nil
+	}
+}
+
+// WithInferDeltaInterval infers the interval for delta sums.
+// By default the interval is set to 0.
+func WithInferDeltaInterval() TranslatorOption {
+	return func(t *translatorConfig) error {
+		t.InferDeltaInterval = true
 		return nil
 	}
 }

--- a/pkg/otlp/metrics/metrics_translator.go
+++ b/pkg/otlp/metrics/metrics_translator.go
@@ -40,6 +40,10 @@ import (
 const (
 	metricName             string = "metric name"
 	errNoBucketsNoSumCount string = "no buckets mode and no send count sum are incompatible"
+
+	// intervalTolerance is the tolerance for interval calculation in seconds
+	// We use 0.1 seconds as tolerance to allow for some jitter.
+	intervalTolerance float64 = 0.1
 )
 
 var (
@@ -61,6 +65,31 @@ var (
 		"kafka.log.flush_rate.rate":                       {},
 	}
 )
+
+// inferDeltaInterval calculates the interval for Datadog counts from OTLP delta sums.
+// It returns the interval in seconds if the time difference between start and end timestamps
+// is close to a whole number of seconds (within intervalTolerance), otherwise returns 0.
+func inferDeltaInterval(startTimestamp, timestamp uint64) int64 {
+	if startTimestamp == 0 {
+		// We can't infer the interval without the startTimestamp
+		return 0
+	}
+
+	// Convert nanoseconds to seconds
+	deltaSeconds := float64(timestamp-startTimestamp) / 1e9
+	if deltaSeconds < 0 {
+		// malformed data
+		return 0
+	}
+	roundedDelta := math.Round(deltaSeconds)
+
+	if math.Abs(roundedDelta-deltaSeconds) < intervalTolerance {
+		return int64(roundedDelta)
+	}
+
+	// delta is outside of tolerance range
+	return 0
+}
 
 var _ source.Provider = (*noSourceProvider)(nil)
 
@@ -169,7 +198,13 @@ func (t *Translator) mapNumberMetrics(
 			continue
 		}
 
-		consumer.ConsumeTimeSeries(ctx, pointDims, dt, uint64(p.Timestamp()), 0, val)
+		// Calculate interval for Count type metrics (from OTLP delta sums)
+		var interval int64
+		if t.cfg.InferDeltaInterval && dt == Count {
+			interval = inferDeltaInterval(uint64(p.StartTimestamp()), uint64(p.Timestamp()))
+		}
+
+		consumer.ConsumeTimeSeries(ctx, pointDims, dt, uint64(p.Timestamp()), interval, val)
 	}
 }
 

--- a/pkg/otlp/metrics/metrics_translator_test.go
+++ b/pkg/otlp/metrics/metrics_translator_test.go
@@ -2345,3 +2345,55 @@ var statsPayloads = []*pb.ClientStatsPayload{
 		},
 	},
 }
+
+func TestInferInterval(t *testing.T) {
+	tests := []struct {
+		name        string
+		startTs, ts uint64
+		expected    int64
+	}{
+		{
+			name:     "exact difference",
+			startTs:  1e9,
+			ts:       11e9,
+			expected: 10,
+		},
+		{
+			name:     "under within tolerance",
+			startTs:  1e9,
+			ts:       11e9 - 50e6,
+			expected: 10,
+		},
+		{
+			name:     "over within tolerance",
+			startTs:  1e9,
+			ts:       11e9 + 50e6,
+			expected: 10,
+		},
+		{
+			name:     "outside tolerance",
+			startTs:  1e9,
+			ts:       11e9 + 50e7,
+			expected: 0,
+		},
+		{
+			name:     "no starttimestamp",
+			startTs:  0,
+			ts:       11e9,
+			expected: 0,
+		},
+		{
+			name:     "malformed data",
+			startTs:  11e9,
+			ts:       1e9,
+			expected: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := inferDeltaInterval(tt.startTs, tt.ts)
+			assert.Equal(t, tt.expected, got)
+		})
+	}
+}


### PR DESCRIPTION
### What does this PR do?

<!--
* A brief description of the change being made with this pull request.
* If the description here cannot be expressed in a succinct form, consider
  opening multiple pull requests instead of a single one.
-->

Adds option to infer interval field. This only works for delta sums that have a `startTimestamp` set. We set the interval if and only if it is 'close' (within the tolerance, fixed to 0.1 seconds) to a whole number of seconds (since the Datadog API only supports a whole number of seconds as an interval). The tolerance accounts for jitter. The solution should be robust against network errors.

### Motivation

<!--
* What inspired you to submit this pull request?
* Link any related GitHub issues or PRs here.
-->

While ultimately we can only set the interval for users in a subset of cases, we can do so in this case reasonably well
